### PR TITLE
Replace rand_core with rand

### DIFF
--- a/.github/workflows/wasm_build.yaml
+++ b/.github/workflows/wasm_build.yaml
@@ -1,0 +1,27 @@
+name: WASM Build
+
+on: [push, pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+          components: rustfmt, clippy
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --manifest-path coconut-rs/Cargo.toml --target wasm32-unknown-unknown
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --manifest-path coconut-rs/Cargo.toml -- --check

--- a/cli-demo-rs/Cargo.lock
+++ b/cli-demo-rs/Cargo.lock
@@ -83,6 +83,7 @@ dependencies = [
  "ff",
  "group",
  "itertools",
+ "lazy_static",
  "rand_core",
  "sha2",
  "sha3",
@@ -173,6 +174,12 @@ name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"

--- a/cli-demo-rs/Cargo.lock
+++ b/cli-demo-rs/Cargo.lock
@@ -61,7 +61,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cli-demo-rs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64",
  "coconut-rs",
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "coconut-rs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bls12_381",
  "digest",

--- a/cli-demo-rs/Cargo.lock
+++ b/cli-demo-rs/Cargo.lock
@@ -48,6 +48,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+
+[[package]]
 name = "byteorder"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +73,7 @@ dependencies = [
  "coconut-rs",
  "digest",
  "ff",
+ "getrandom",
  "group",
  "rand",
  "read_input",
@@ -80,6 +87,7 @@ dependencies = [
  "bls12_381",
  "digest",
  "ff",
+ "getrandom",
  "group",
  "itertools",
  "rand",
@@ -142,8 +150,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -168,16 +178,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+
+[[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -199,6 +233,24 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "radium"
@@ -284,6 +336,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
+name = "syn"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +359,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
 name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +375,60 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "wyz"

--- a/cli-demo-rs/Cargo.lock
+++ b/cli-demo-rs/Cargo.lock
@@ -8,9 +8,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitvec"
-version = "0.20.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5011ffc90248764d7005b0e10c7294f5aa1bd87d9dd7248f4ad475b347c294d"
+checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
 dependencies = [
  "funty",
  "radium",
@@ -36,9 +36,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bls12_381"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c56609cc42c628848e7b18e0baf42a4ef626b8c50442dc08b8094bd21d8ad32"
+checksum = "54757888b09a69be70b5ec303e382a74227392086ba808cb01eeca29233a2397"
 dependencies = [
  "ff",
  "group",
@@ -69,7 +69,6 @@ dependencies = [
  "ff",
  "group",
  "rand",
- "rand_core",
  "read_input",
  "sha2",
 ]
@@ -83,8 +82,7 @@ dependencies = [
  "ff",
  "group",
  "itertools",
- "lazy_static",
- "rand_core",
+ "rand",
  "sha2",
  "sha3",
 ]
@@ -112,9 +110,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "ff"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a4d941a5b7c2a75222e2d44fcdf634a67133d9db31e177ae5ff6ecda852bfe"
+checksum = "63eec06c61e487eecf0f7e6e6372e596a81922c28d33e645d6983ca6493a1af0"
 dependencies = [
  "bitvec",
  "rand_core",
@@ -123,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "funty"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 
 [[package]]
 name = "generic-array"
@@ -150,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3c1e8b4f1ca07e6605ea1be903a5f6956aec5c8a67fd44d56076631675ed8"
+checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
  "byteorder",
  "ff",
@@ -176,12 +174,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,11 +187,10 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pairing"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be899ebf10363f018353dba1baabb7e83145f3683c7b83b73b93b563e3167cc"
+checksum = "7de9d09263c9966e8196fe0380c9dbbc7ea114b5cf371ba29004bc1f9c6db7f3"
 dependencies = [
- "ff",
  "group",
 ]
 
@@ -318,6 +309,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wyz"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+dependencies = [
+ "tap",
+]

--- a/cli-demo-rs/Cargo.toml
+++ b/cli-demo-rs/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-coconut-rs = { path = "../coconut-rs"}
+coconut-rs = { path="../coconut-rs" }
 base64 = "0.13.0"
 read_input = "0.8.4"
 #crossterm = { version = "0.19"}
@@ -21,13 +21,9 @@ digest = "0.9.0"
 rand = "0.8.3"
 
 [dependencies.ff]
-version = "0.9"
+version = "0.10"
 default-features = false
 
 [dependencies.group]
-version = "0.9"
+version = "0.10"
 default-features = false
-
-[dependencies.rand_core]
-version = "0.6.1"
-features = ["getrandom"]

--- a/cli-demo-rs/Cargo.toml
+++ b/cli-demo-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli-demo-rs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jędrzej Stuczyński <jedrzej.stuczynski@gmail.com>"]
 edition = "2018"
 

--- a/cli-demo-rs/Cargo.toml
+++ b/cli-demo-rs/Cargo.toml
@@ -27,3 +27,7 @@ default-features = false
 [dependencies.group]
 version = "0.10"
 default-features = false
+
+[target.'cfg(target_env = "wasm32-unknown-unknown")'.dependencies]
+getrandom = {version="*", features = ["js"]}
+

--- a/cli-demo-rs/src/main.rs
+++ b/cli-demo-rs/src/main.rs
@@ -6,7 +6,6 @@ use coconut_rs::scheme::{BlindedSignature, Signature, SignatureShare, Verificati
 use coconut_rs::{elgamal, Attribute};
 use digest::Digest;
 use rand::seq::SliceRandom;
-use rand_core::OsRng;
 use read_input::prelude::*;
 use sha2::digest::generic_array::typenum::Unsigned;
 use sha2::Sha256;
@@ -341,7 +340,7 @@ fn main() {
 
     println!("Choosing {} random signatures to aggregate...", t);
     let sample: Vec<_> = indices
-        .choose_multiple(&mut OsRng, t as usize)
+        .choose_multiple(&mut rand::thread_rng(), t as usize)
         .copied()
         .collect();
     println!("Chosen indices: {:?}", sample);

--- a/coconut-rs/Cargo.toml
+++ b/coconut-rs/Cargo.toml
@@ -11,6 +11,7 @@ bls12_381 = "0.4.0"
 itertools = "0.10.0"
 digest = "0.9.0"
 rand_core = "0.6.1"
+lazy_static = "1.4"
 
 #[dependencies.zeroize]
 #version = "1.2.0"

--- a/coconut-rs/Cargo.toml
+++ b/coconut-rs/Cargo.toml
@@ -7,11 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bls12_381 = "0.4.0"
+bls12_381 = "0.5.0"
 itertools = "0.10.0"
 digest = "0.9.0"
-rand_core = "0.6.1"
-lazy_static = "1.4"
+rand = "0.8.3"
 
 #[dependencies.zeroize]
 #version = "1.2.0"
@@ -27,16 +26,12 @@ optional = true
 default-features = false
 
 [dependencies.ff]
-version = "0.9"
+version = "0.10"
 default-features = false
 
 [dependencies.group]
-version = "0.9"
+version = "0.10"
 default-features = false
-
-[dev-dependencies.rand_core]
-version = "0.6.1"
-features = ["getrandom"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/coconut-rs/Cargo.toml
+++ b/coconut-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coconut-rs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jędrzej Stuczyński <andrew@nymtech.net>"]
 edition = "2018"
 

--- a/coconut-rs/Cargo.toml
+++ b/coconut-rs/Cargo.toml
@@ -11,7 +11,7 @@ bls12_381 = "0.5.0"
 itertools = "0.10.0"
 digest = "0.9.0"
 rand = "0.8.3"
-
+getrandom = "*"
 #[dependencies.zeroize]
 #version = "1.2.0"
 #features = ["zeroize_derive"]
@@ -45,3 +45,6 @@ harness = false
 
 [features]
 default = []
+
+[target.'cfg(target_env = "wasm32-unknown-unknown")'.dependencies]
+getrandom = { version="*", features=["js"] }

--- a/coconut-rs/benches/benchmarks.rs
+++ b/coconut-rs/benches/benchmarks.rs
@@ -16,7 +16,6 @@ use bls12_381::{multi_miller_loop, G1Affine, G2Affine, G2Prepared, Scalar};
 use criterion::{criterion_group, criterion_main, Criterion};
 use ff::Field;
 use group::{Curve, Group};
-use rand_core::OsRng;
 use std::ops::Neg;
 
 fn double_pairing(g11: &G1Affine, g21: &G2Affine, g12: &G1Affine, g22: &G2Affine) {
@@ -62,7 +61,7 @@ fn multi_miller_pairing_with_semi_prepared(
 }
 
 fn bench_pairings(c: &mut Criterion) {
-    let mut rng = OsRng;
+    let mut rng = rand::thread_rng();
 
     let g1 = G1Affine::generator();
     let g2 = G2Affine::generator();

--- a/coconut-rs/src/elgamal.rs
+++ b/coconut-rs/src/elgamal.rs
@@ -18,7 +18,6 @@ use crate::utils::{try_deserialize_g1_projective, try_deserialize_scalar};
 use bls12_381::{G1Projective, Scalar};
 use core::ops::{Deref, Mul};
 use group::Curve;
-use rand_core::{CryptoRng, RngCore};
 
 #[cfg(feature = "serde")]
 use serde::de::Visitor;
@@ -80,7 +79,7 @@ impl PrivateKey {
         c2 - c1 * self.0
     }
 
-    pub fn public_key<R: RngCore + CryptoRng>(&self, params: &Parameters) -> PublicKey {
+    pub fn public_key(&self, params: &Parameters) -> PublicKey {
         PublicKey(params.gen1() * self.0)
     }
 

--- a/coconut-rs/src/elgamal.rs
+++ b/coconut-rs/src/elgamal.rs
@@ -80,7 +80,7 @@ impl PrivateKey {
         c2 - c1 * self.0
     }
 
-    pub fn public_key<R: RngCore + CryptoRng>(&self, params: &Parameters<R>) -> PublicKey {
+    pub fn public_key<R: RngCore + CryptoRng>(&self, params: &Parameters) -> PublicKey {
         PublicKey(params.gen1() * self.0)
     }
 
@@ -107,9 +107,9 @@ impl PublicKey {
     /// where h is a point on the G1 curve using the given public key.
     /// The random k is returned alongside the encryption
     /// as it is required by the Coconut Scheme to create proofs of knowledge.
-    pub fn encrypt<R: RngCore + CryptoRng>(
+    pub fn encrypt(
         &self,
-        params: &mut Parameters<R>,
+        params: &mut Parameters,
         h: &G1Projective,
         msg: &Scalar,
     ) -> (Ciphertext, EphemeralKey) {
@@ -167,7 +167,7 @@ impl KeyPair {
 }
 
 /// Generate a fresh ElGamal keypair using the group generator specified by the provided [Parameters]
-pub fn keygen<R: RngCore + CryptoRng>(params: &mut Parameters<R>) -> KeyPair {
+pub fn keygen(params: &mut Parameters) -> KeyPair {
     let private_key = params.random_scalar();
     let gamma = params.gen1() * private_key;
 

--- a/coconut-rs/src/lib.rs
+++ b/coconut-rs/src/lib.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use bls12_381::Scalar;
+use lazy_static::lazy_static;
+use rand_core::OsRng;
 use sha3::Sha3_384;
 
 pub mod elgamal;
@@ -26,3 +28,7 @@ pub type Attribute = Scalar;
 // reason for sha3 384 is for the 48 bytes output and it's a good enough solution
 // for the temporary use it has
 pub(crate) type G1HashDigest = Sha3_384;
+
+lazy_static! {
+    static ref RNG: OsRng = OsRng;
+}

--- a/coconut-rs/src/lib.rs
+++ b/coconut-rs/src/lib.rs
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 use bls12_381::Scalar;
-use lazy_static::lazy_static;
-use rand_core::OsRng;
 use sha3::Sha3_384;
 
 pub mod elgamal;
@@ -28,7 +26,3 @@ pub type Attribute = Scalar;
 // reason for sha3 384 is for the 48 bytes output and it's a good enough solution
 // for the temporary use it has
 pub(crate) type G1HashDigest = Sha3_384;
-
-lazy_static! {
-    static ref RNG: OsRng = OsRng;
-}

--- a/coconut-rs/src/proofs/mod.rs
+++ b/coconut-rs/src/proofs/mod.rs
@@ -522,11 +522,11 @@ mod tests {
     use crate::scheme::keygen::keygen;
     use crate::scheme::setup::setup;
     use group::Group;
-    use rand_core::OsRng;
+    use rand::thread_rng;
 
     #[test]
     fn proof_cm_cs_bytes_roundtrip() {
-        let mut rng = OsRng;
+        let mut rng = thread_rng();
         let mut params = setup(1).unwrap();
 
         let elgamal_keypair = elgamal::keygen(&mut params);

--- a/coconut-rs/src/proofs/mod.rs
+++ b/coconut-rs/src/proofs/mod.rs
@@ -24,7 +24,6 @@ use digest::generic_array::typenum::Unsigned;
 use digest::Digest;
 use group::GroupEncoding;
 use itertools::izip;
-use rand_core::{CryptoRng, RngCore};
 use sha2::Sha256;
 use std::borrow::Borrow;
 use std::convert::TryInto;
@@ -96,8 +95,8 @@ where
 
 impl ProofCmCs {
     /// Construct non-interactive zero-knowledge proof of correctness of the ciphertexts and the commitment.
-    pub(crate) fn construct<R: RngCore + CryptoRng>(
-        params: &mut Parameters<R>,
+    pub(crate) fn construct(
+        params: &mut Parameters,
         pub_key: &elgamal::PublicKey,
         ephemeral_keys: &[elgamal::EphemeralKey],
         commitment: &G1Projective,
@@ -186,9 +185,9 @@ impl ProofCmCs {
         }
     }
 
-    pub(crate) fn verify<R>(
+    pub(crate) fn verify(
         &self,
-        params: &Parameters<R>,
+        params: &Parameters,
         pub_key: &elgamal::PublicKey,
         commitment: &G1Projective,
         attributes_ciphertexts: &[elgamal::Ciphertext],
@@ -340,8 +339,8 @@ pub struct ProofKappaNu {
 }
 
 impl ProofKappaNu {
-    pub(crate) fn construct<R: RngCore + CryptoRng>(
-        params: &mut Parameters<R>,
+    pub(crate) fn construct(
+        params: &mut Parameters,
         verification_key: &VerificationKey,
         signature: &Signature,
         private_attributes: &[Attribute],
@@ -405,9 +404,9 @@ impl ProofKappaNu {
         self.response_attributes.len()
     }
 
-    pub(crate) fn verify<R>(
+    pub(crate) fn verify(
         &self,
-        params: &Parameters<R>,
+        params: &Parameters,
         verification_key: &VerificationKey,
         signature: &Signature,
         // TODO NAMING: kappa, nu...
@@ -528,15 +527,14 @@ mod tests {
     #[test]
     fn proof_cm_cs_bytes_roundtrip() {
         let mut rng = OsRng;
-        let mut rng2 = OsRng;
-        let mut params = setup(&mut rng, 1).unwrap();
+        let mut params = setup(1).unwrap();
 
         let elgamal_keypair = elgamal::keygen(&mut params);
         let private_attributes = params.n_random_scalars(1);
         let public_attributes = params.n_random_scalars(0);
 
         // we don't care about 'correctness' of the proof. only whether we can correctly recover it from bytes
-        let cm = G1Projective::random(&mut rng2);
+        let cm = G1Projective::random(&mut rng);
         let r = params.random_scalar();
 
         let ephemeral_keys = params.n_random_scalars(1);
@@ -576,8 +574,7 @@ mod tests {
 
     #[test]
     fn proof_kappa_nu_bytes_roundtrip() {
-        let mut rng = OsRng;
-        let mut params = setup(&mut rng, 1).unwrap();
+        let mut params = setup(1).unwrap();
 
         let keypair = keygen(&mut params);
         let r = params.random_scalar();
@@ -601,7 +598,7 @@ mod tests {
         assert_eq!(ProofKappaNu::from_bytes(&bytes).unwrap(), pi_v);
 
         // 2 public 2 private
-        let mut params = setup(&mut rng, 4).unwrap();
+        let mut params = setup(4).unwrap();
         let keypair = keygen(&mut params);
         let private_attributes = params.n_random_scalars(2);
 

--- a/coconut-rs/src/scheme/aggregation.rs
+++ b/coconut-rs/src/scheme/aggregation.rs
@@ -126,9 +126,7 @@ mod tests {
 
     #[test]
     fn key_aggregation_works_for_any_subset_of_keys() {
-        let rng = OsRng;
-
-        let mut params = Parameters::new(rng, 2).unwrap();
+        let mut params = Parameters::new(2).unwrap();
         let keypairs = ttp_keygen(&mut params, 3, 5).unwrap();
 
         let vks = keypairs
@@ -189,9 +187,7 @@ mod tests {
 
     #[test]
     fn signature_aggregation_works_for_any_subset_of_signatures() {
-        let rng = OsRng;
-
-        let mut params = Parameters::new(rng, 2).unwrap();
+        let mut params = Parameters::new(2).unwrap();
         let attributes = params.n_random_scalars(2);
 
         let keypairs = ttp_keygen(&mut params, 3, 5).unwrap();

--- a/coconut-rs/src/scheme/aggregation.rs
+++ b/coconut-rs/src/scheme/aggregation.rs
@@ -122,7 +122,6 @@ mod tests {
     use crate::scheme::verification::verify;
     use bls12_381::G1Projective;
     use group::Group;
-    use rand_core::OsRng;
 
     #[test]
     fn key_aggregation_works_for_any_subset_of_keys() {
@@ -229,7 +228,7 @@ mod tests {
     }
 
     fn random_signature() -> Signature {
-        let mut rng = OsRng;
+        let mut rng = rand::thread_rng();
         Signature(
             G1Projective::random(&mut rng),
             G1Projective::random(&mut rng),

--- a/coconut-rs/src/scheme/mod.rs
+++ b/coconut-rs/src/scheme/mod.rs
@@ -148,7 +148,6 @@ mod tests {
 
     #[test]
     fn verification_on_two_public_attributes() {
-
         let mut params = Parameters::new(2).unwrap();
         let attributes = params.n_random_scalars(2);
 

--- a/coconut-rs/src/scheme/mod.rs
+++ b/coconut-rs/src/scheme/mod.rs
@@ -23,7 +23,6 @@ use crate::utils::try_deserialize_g1_projective;
 use bls12_381::G1Projective;
 use group::Curve;
 pub use keygen::{SecretKey, VerificationKey};
-use rand_core::{CryptoRng, RngCore};
 
 pub mod aggregation;
 pub mod issuance;
@@ -51,7 +50,7 @@ impl Signature {
         &self.1
     }
 
-    pub fn randomise<R: RngCore + CryptoRng>(&self, params: &mut Parameters<R>) -> Signature {
+    pub fn randomise(&self, params: &mut Parameters) -> Signature {
         let r = params.random_scalar();
         Signature(self.0 * r, self.1 * r)
     }
@@ -146,13 +145,11 @@ mod tests {
     use crate::scheme::issuance::{blind_sign, prepare_blind_sign, sign};
     use crate::scheme::keygen::{keygen, ttp_keygen};
     use crate::scheme::verification::{prove_credential, verify, verify_credential};
-    use rand_core::OsRng;
 
     #[test]
     fn verification_on_two_public_attributes() {
-        let rng = OsRng;
 
-        let mut params = Parameters::new(rng, 2).unwrap();
+        let mut params = Parameters::new(2).unwrap();
         let attributes = params.n_random_scalars(2);
 
         let keypair1 = keygen(&mut params);
@@ -184,9 +181,7 @@ mod tests {
 
     #[test]
     fn verification_on_two_public_and_two_private_attributes() {
-        let rng = OsRng;
-
-        let mut params = Parameters::new(rng, 4).unwrap();
+        let mut params = Parameters::new(4).unwrap();
         let public_attributes = params.n_random_scalars(2);
         let private_attributes = params.n_random_scalars(2);
         let elgamal_keypair = elgamal::keygen(&mut params);
@@ -260,9 +255,7 @@ mod tests {
 
     #[test]
     fn verification_on_two_public_and_two_private_attributes_from_two_signers() {
-        let rng = OsRng;
-
-        let mut params = Parameters::new(rng, 4).unwrap();
+        let mut params = Parameters::new(4).unwrap();
         let public_attributes = params.n_random_scalars(2);
         let private_attributes = params.n_random_scalars(2);
         let elgamal_keypair = elgamal::keygen(&mut params);

--- a/coconut-rs/src/scheme/setup.rs
+++ b/coconut-rs/src/scheme/setup.rs
@@ -14,10 +14,10 @@
 
 use crate::error::{Error, ErrorKind, Result};
 use crate::utils::hash_g1;
-use crate::RNG;
 use bls12_381::{G1Affine, G2Affine, G2Prepared, Scalar};
 use ff::Field;
 use group::Curve;
+use rand::thread_rng;
 
 /// System-wide parameters used for the protocol
 pub struct Parameters {
@@ -72,7 +72,9 @@ impl Parameters {
     }
 
     pub(crate) fn random_scalar(&mut self) -> Scalar {
-        Scalar::random(*RNG)
+        // lazily-initialized thread-local random number generator, seeded by the system
+        let mut rng = thread_rng();
+        Scalar::random(&mut rng)
     }
 
     pub(crate) fn n_random_scalars(&mut self, n: usize) -> Vec<Scalar> {

--- a/coconut-rs/src/utils.rs
+++ b/coconut-rs/src/utils.rs
@@ -32,10 +32,7 @@ pub struct Polynomial {
 impl Polynomial {
     // for polynomial of degree n, we generate n+1 values
     // (for example for degree 1, like y = x + 2, we need [2,1])
-    pub(crate) fn new_random(
-        params: &mut Parameters,
-        degree: u64,
-    ) -> Self {
+    pub(crate) fn new_random(params: &mut Parameters, degree: u64) -> Self {
         Polynomial {
             coefficients: params.n_random_scalars((degree + 1) as usize),
         }
@@ -328,7 +325,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand_core::RngCore;
+    use rand::RngCore;
 
     #[test]
     fn polynomial_evaluation() {
@@ -431,7 +428,7 @@ mod tests {
 
     #[test]
     fn hash_g1_sanity_check() {
-        let mut rng = rand_core::OsRng;
+        let mut rng = rand::thread_rng();
         let mut msg1 = [0u8; 1024];
         rng.fill_bytes(&mut msg1);
         let mut msg2 = [0u8; 1024];

--- a/coconut-rs/src/utils.rs
+++ b/coconut-rs/src/utils.rs
@@ -23,7 +23,6 @@ use digest::generic_array;
 use digest::generic_array::typenum::Unsigned;
 use digest::Digest;
 use ff::Field;
-use rand_core::{CryptoRng, RngCore};
 use std::convert::TryInto;
 
 pub struct Polynomial {
@@ -33,8 +32,8 @@ pub struct Polynomial {
 impl Polynomial {
     // for polynomial of degree n, we generate n+1 values
     // (for example for degree 1, like y = x + 2, we need [2,1])
-    pub(crate) fn new_random<R: RngCore + CryptoRng>(
-        params: &mut Parameters<R>,
+    pub(crate) fn new_random(
+        params: &mut Parameters,
         degree: u64,
     ) -> Self {
         Polynomial {
@@ -329,6 +328,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand_core::RngCore;
 
     #[test]
     fn polynomial_evaluation() {


### PR DESCRIPTION
+ We no longer need to have a random generator in Paremeters, `thread_rng` should be functionally equivalent to `OsRng` we've been using
+ Bumps dependencies to latest versions