### PR TITLE
Impl TryFroms, remove some copying

### DIFF
--- a/coconut-rs/src/elgamal.rs
+++ b/coconut-rs/src/elgamal.rs
@@ -19,6 +19,7 @@ use bls12_381::{G1Projective, Scalar};
 use core::ops::{Deref, Mul};
 use group::Curve;
 use std::convert::TryFrom;
+use std::convert::TryInto;
 
 #[cfg(feature = "serde")]
 use serde::de::Visitor;
@@ -44,11 +45,9 @@ impl TryFrom<&[u8]> for Ciphertext {
             ));
         }
 
-        let mut c1_bytes = [0u8; 48];
-        let mut c2_bytes = [0u8; 48];
+        let c1_bytes: &[u8; 48] = &bytes[..48].try_into().expect("Slice size != 48");
+        let c2_bytes: &[u8; 48] = &bytes[48..].try_into().expect("Slice size != 48");
 
-        c1_bytes.copy_from_slice(&bytes[..48]);
-        c2_bytes.copy_from_slice(&bytes[48..]);
 
         let c1 =
             try_deserialize_g1_projective(&c1_bytes, || "failed to deserialize compressed c1")?;

--- a/coconut-rs/src/elgamal.rs
+++ b/coconut-rs/src/elgamal.rs
@@ -48,7 +48,6 @@ impl TryFrom<&[u8]> for Ciphertext {
         let c1_bytes: &[u8; 48] = &bytes[..48].try_into().expect("Slice size != 48");
         let c2_bytes: &[u8; 48] = &bytes[48..].try_into().expect("Slice size != 48");
 
-
         let c1 =
             try_deserialize_g1_projective(&c1_bytes, || "failed to deserialize compressed c1")?;
         let c2 =

--- a/coconut-rs/src/elgamal.rs
+++ b/coconut-rs/src/elgamal.rs
@@ -400,7 +400,7 @@ mod tests {
 
     #[test]
     fn private_key_bytes_roundtrip() {
-        let mut params = Parameters::default();
+        let params = Parameters::default();
         let private_key = PrivateKey(params.random_scalar());
         let bytes = private_key.to_bytes();
 
@@ -411,7 +411,7 @@ mod tests {
 
     #[test]
     fn public_key_bytes_roundtrip() {
-        let mut params = Parameters::default();
+        let params = Parameters::default();
         let r = params.random_scalar();
         let public_key = PublicKey(params.gen1() * r);
         let bytes = public_key.to_bytes();
@@ -423,7 +423,7 @@ mod tests {
 
     #[test]
     fn ciphertext_bytes_roundtrip() {
-        let mut params = Parameters::default();
+        let params = Parameters::default();
         let r = params.random_scalar();
         let s = params.random_scalar();
         let ciphertext = Ciphertext(params.gen1() * r, params.gen1() * s);

--- a/coconut-rs/src/scheme/issuance.rs
+++ b/coconut-rs/src/scheme/issuance.rs
@@ -66,8 +66,7 @@ impl TryFrom<&[u8]> for BlindSignRequest {
         for i in 0..c_len as usize {
             let start = 56 + i * 96;
             let end = start + 96;
-            let c_bytes = bytes[start..end].try_into().unwrap();
-            attributes_ciphertexts.push(Ciphertext::from_bytes(&c_bytes)?)
+            attributes_ciphertexts.push(Ciphertext::try_from(&bytes[start..end])?)
         }
 
         let pi_s = ProofCmCs::from_bytes(&bytes[56 + c_len as usize * 96..])?;

--- a/coconut-rs/src/scheme/keygen.rs
+++ b/coconut-rs/src/scheme/keygen.rs
@@ -375,7 +375,7 @@ pub struct KeyPair {
 /// Generate a single Coconut keypair ((x, y0, y1...), (g2^x, g2^y0, ...)).
 /// It is not suitable for threshold credentials as all subsequent calls to `keygen` generate keys
 /// that are independent of each other.
-pub fn keygen(params: &mut Parameters) -> KeyPair {
+pub fn keygen(params: &Parameters) -> KeyPair {
     let attributes = params.gen_hs().len();
 
     let x = params.random_scalar();

--- a/coconut-rs/src/scheme/keygen.rs
+++ b/coconut-rs/src/scheme/keygen.rs
@@ -24,6 +24,7 @@ use core::borrow::Borrow;
 use core::iter::Sum;
 use core::ops::{Add, Mul};
 use group::Curve;
+use std::convert::TryFrom;
 use std::convert::TryInto;
 
 #[cfg(feature = "serde")]
@@ -105,21 +106,10 @@ pub struct VerificationKey {
     pub(crate) beta: Vec<G2Projective>,
 }
 
-impl VerificationKey {
-    // alpha || beta.len() || beta
-    pub fn to_bytes(&self) -> Vec<u8> {
-        let beta_len = self.beta.len() as u64;
-        let mut bytes = Vec::with_capacity(8 + (beta_len + 1) as usize * 96);
+impl TryFrom<&[u8]> for VerificationKey {
+    type Error = crate::error::Error;
 
-        bytes.extend_from_slice(&self.alpha.to_affine().to_compressed());
-        bytes.extend_from_slice(&beta_len.to_le_bytes());
-        for beta in self.beta.iter() {
-            bytes.extend_from_slice(&beta.to_affine().to_compressed())
-        }
-        bytes
-    }
-
-    pub fn from_bytes(bytes: &[u8]) -> Result<VerificationKey> {
+    fn try_from(bytes: &[u8]) -> Result<VerificationKey> {
         if bytes.len() < 96 * 2 + 8 || (bytes.len() - 8) % 96 != 0 {
             return Err(Error::new(
                 ErrorKind::Deserialization,
@@ -235,6 +225,18 @@ impl VerificationKey {
 
     pub fn aggregate(sigs: &[Self], indices: Option<&[SignerIndex]>) -> Result<Self> {
         aggregate_verification_keys(sigs, indices)
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let beta_len = self.beta.len() as u64;
+        let mut bytes = Vec::with_capacity(8 + (beta_len + 1) as usize * 96);
+
+        bytes.extend_from_slice(&self.alpha.to_affine().to_compressed());
+        bytes.extend_from_slice(&beta_len.to_le_bytes());
+        for beta in self.beta.iter() {
+            bytes.extend_from_slice(&beta.to_affine().to_compressed())
+        }
+        bytes
     }
 }
 
@@ -476,18 +478,18 @@ mod tests {
         let mut params1 = setup(1).unwrap();
         let mut params5 = setup(5).unwrap();
 
-        let keypair1 = keygen(&mut params1);
-        let keypair5 = keygen(&mut params5);
+        let keypair1 = &keygen(&mut params1);
+        let keypair5 = &keygen(&mut params5);
 
-        let bytes1 = keypair1.verification_key.to_bytes();
-        let bytes5 = keypair5.verification_key.to_bytes();
+        let bytes1: Vec<u8> = keypair1.verification_key.to_bytes();
+        let bytes5: Vec<u8> = keypair5.verification_key.to_bytes();
 
         assert_eq!(
-            VerificationKey::from_bytes(&bytes1).unwrap(),
+            VerificationKey::try_from(bytes1.as_slice()).unwrap(),
             keypair1.verification_key
         );
         assert_eq!(
-            VerificationKey::from_bytes(&bytes5).unwrap(),
+            VerificationKey::try_from(bytes5.as_slice()).unwrap(),
             keypair5.verification_key
         );
     }

--- a/coconut-rs/src/scheme/keygen.rs
+++ b/coconut-rs/src/scheme/keygen.rs
@@ -107,7 +107,7 @@ pub struct VerificationKey {
 }
 
 impl TryFrom<&[u8]> for VerificationKey {
-    type Error = crate::error::Error;
+    type Error = Error;
 
     fn try_from(bytes: &[u8]) -> Result<VerificationKey> {
         if bytes.len() < 96 * 2 + 8 || (bytes.len() - 8) % 96 != 0 {

--- a/coconut-rs/src/scheme/mod.rs
+++ b/coconut-rs/src/scheme/mod.rs
@@ -319,7 +319,7 @@ mod tests {
 
     #[test]
     fn signature_bytes_roundtrip() {
-        let mut params = Parameters::default();
+        let params = Parameters::default();
         let r = params.random_scalar();
         let s = params.random_scalar();
         let signature = Signature(params.gen1() * r, params.gen1() * s);
@@ -337,7 +337,7 @@ mod tests {
 
     #[test]
     fn blinded_signature_bytes_roundtrip() {
-        let mut params = Parameters::default();
+        let params = Parameters::default();
         let r = params.random_scalar();
         let s = params.random_scalar();
         let t = params.random_scalar();

--- a/coconut-rs/src/scheme/mod.rs
+++ b/coconut-rs/src/scheme/mod.rs
@@ -24,6 +24,7 @@ use bls12_381::G1Projective;
 use group::Curve;
 pub use keygen::{SecretKey, VerificationKey};
 use std::convert::TryFrom;
+use std::convert::TryInto;
 
 pub mod aggregation;
 pub mod issuance;
@@ -53,11 +54,8 @@ impl TryFrom<&[u8]> for Signature {
             ));
         }
 
-        let mut sig1_bytes = [0u8; 48];
-        let mut sig2_bytes = [0u8; 48];
-
-        sig1_bytes.copy_from_slice(&bytes[..48]);
-        sig2_bytes.copy_from_slice(&bytes[48..]);
+        let sig1_bytes: &[u8; 48] = &bytes[..48].try_into().expect("Slice size != 48");
+        let sig2_bytes: &[u8; 48] = &bytes[48..].try_into().expect("Slice size != 48");
 
         let sig1 =
             try_deserialize_g1_projective(&sig1_bytes, || "failed to deserialize compressed sig1")?;
@@ -106,13 +104,14 @@ impl TryFrom<&[u8]> for BlindedSignature {
         if bytes.len() != 144 {
             return Err(Error::new(
                 ErrorKind::Deserialization,
-                format!("BlindedSignature must be exactly 144 bytes, got {}", bytes.len()),
+                format!(
+                    "BlindedSignature must be exactly 144 bytes, got {}",
+                    bytes.len()
+                ),
             ));
         }
 
-        let mut h_bytes = [0u8; 48];
-
-        h_bytes.copy_from_slice(&bytes[..48]);
+        let h_bytes: &[u8; 48] = &bytes[..48].try_into().expect("Slice size != 48");
 
         let h = try_deserialize_g1_projective(&h_bytes, || "failed to deserialize compressed h")?;
         let c_tilde = Ciphertext::try_from(&bytes[48..])?;

--- a/coconut-rs/src/scheme/mod.rs
+++ b/coconut-rs/src/scheme/mod.rs
@@ -23,6 +23,7 @@ use crate::utils::try_deserialize_g1_projective;
 use bls12_381::G1Projective;
 use group::Curve;
 pub use keygen::{SecretKey, VerificationKey};
+use std::convert::TryFrom;
 
 pub mod aggregation;
 pub mod issuance;
@@ -108,7 +109,7 @@ impl BlindedSignature {
         c_tilde_bytes.copy_from_slice(&bytes[48..]);
 
         let h = try_deserialize_g1_projective(&h_bytes, || "failed to deserialize compressed h")?;
-        let c_tilde = Ciphertext::from_bytes(&c_tilde_bytes)?;
+        let c_tilde = Ciphertext::try_from(&bytes[48..])?;
 
         Ok(BlindedSignature(h, c_tilde))
     }

--- a/coconut-rs/src/scheme/setup.rs
+++ b/coconut-rs/src/scheme/setup.rs
@@ -71,13 +71,13 @@ impl Parameters {
         &self.hs
     }
 
-    pub(crate) fn random_scalar(&mut self) -> Scalar {
+    pub(crate) fn random_scalar(&self) -> Scalar {
         // lazily-initialized thread-local random number generator, seeded by the system
         let mut rng = thread_rng();
         Scalar::random(&mut rng)
     }
 
-    pub(crate) fn n_random_scalars(&mut self, n: usize) -> Vec<Scalar> {
+    pub(crate) fn n_random_scalars(&self, n: usize) -> Vec<Scalar> {
         (0..n).map(|_| self.random_scalar()).collect()
     }
 }

--- a/coconut-rs/src/scheme/verification.rs
+++ b/coconut-rs/src/scheme/verification.rs
@@ -57,8 +57,7 @@ impl TryFrom<&[u8]> for Theta {
         let nu_bytes = bytes[96..144].try_into().unwrap();
         let nu = try_deserialize_g1_projective(&nu_bytes, || "failed to deserialize kappa")?;
 
-        let credential_bytes = bytes[144..240].try_into().unwrap();
-        let credential = Signature::from_bytes(&credential_bytes)?;
+        let credential = Signature::try_from(&bytes[144..240])?;
 
         let pi_v = ProofKappaNu::from_bytes(&bytes[240..])?;
 

--- a/coconut-rs/src/scheme/verification.rs
+++ b/coconut-rs/src/scheme/verification.rs
@@ -22,6 +22,7 @@ use crate::Attribute;
 use bls12_381::{multi_miller_loop, G1Affine, G1Projective, G2Prepared, G2Projective};
 use core::ops::Neg;
 use group::{Curve, Group};
+use std::convert::TryFrom;
 use std::convert::TryInto;
 
 // TODO NAMING: this whole thing
@@ -37,6 +38,37 @@ pub struct Theta {
     credential: Signature,
     // pi_v
     pi_v: ProofKappaNu,
+}
+
+impl TryFrom<&[u8]> for Theta {
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Theta> {
+        if bytes.len() < 240 {
+            return Err(Error::new(
+                ErrorKind::Deserialization,
+                "tried to deserialize theta with insufficient number of bytes",
+            ));
+        }
+
+        let kappa_bytes = bytes[..96].try_into().unwrap();
+        let kappa = try_deserialize_g2_projective(&kappa_bytes, || "failed to deserialize kappa")?;
+
+        let nu_bytes = bytes[96..144].try_into().unwrap();
+        let nu = try_deserialize_g1_projective(&nu_bytes, || "failed to deserialize kappa")?;
+
+        let credential_bytes = bytes[144..240].try_into().unwrap();
+        let credential = Signature::from_bytes(&credential_bytes)?;
+
+        let pi_v = ProofKappaNu::from_bytes(&bytes[240..])?;
+
+        Ok(Theta {
+            kappa,
+            nu,
+            credential,
+            pi_v,
+        })
+    }
 }
 
 impl Theta {
@@ -67,33 +99,6 @@ impl Theta {
         bytes.extend_from_slice(&proof_bytes);
 
         bytes
-    }
-
-    pub fn from_bytes(bytes: &[u8]) -> Result<Theta> {
-        if bytes.len() < 240 {
-            return Err(Error::new(
-                ErrorKind::Deserialization,
-                "tried to deserialize theta with insufficient number of bytes",
-            ));
-        }
-
-        let kappa_bytes = bytes[..96].try_into().unwrap();
-        let kappa = try_deserialize_g2_projective(&kappa_bytes, || "failed to deserialize kappa")?;
-
-        let nu_bytes = bytes[96..144].try_into().unwrap();
-        let nu = try_deserialize_g1_projective(&nu_bytes, || "failed to deserialize kappa")?;
-
-        let credential_bytes = bytes[144..240].try_into().unwrap();
-        let credential = Signature::from_bytes(&credential_bytes)?;
-
-        let pi_v = ProofKappaNu::from_bytes(&bytes[240..])?;
-
-        Ok(Theta {
-            kappa,
-            nu,
-            credential,
-            pi_v,
-        })
     }
 }
 
@@ -252,7 +257,7 @@ mod tests {
         .unwrap();
 
         let bytes = theta.to_bytes();
-        assert_eq!(Theta::from_bytes(&bytes).unwrap(), theta);
+        assert_eq!(Theta::try_from(bytes.as_slice()).unwrap(), theta);
 
         let mut params = setup(4).unwrap();
 
@@ -268,6 +273,6 @@ mod tests {
         .unwrap();
 
         let bytes = theta.to_bytes();
-        assert_eq!(Theta::from_bytes(&bytes).unwrap(), theta);
+        assert_eq!(Theta::try_from(bytes.as_slice()).unwrap(), theta);
     }
 }


### PR DESCRIPTION
Impls `TryFrom` for most (maybe all structs). I've opted to do `TryFrom<&[u8]>`, so `try_from()` has a bounds check where applicable. We might have gotten a slight performance improvement in the process, but that is not the point here, I'm trying to make code more idiomatic. 