### PR TITLE
Base58 trait

### DIFF
--- a/coconut-rs/Cargo.toml
+++ b/coconut-rs/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bls12_381 = "0.4"
+bls12_381 = "0.5"
 itertools = "0.10"
 digest = "0.9"
 rand = "0.8"
@@ -16,16 +16,17 @@ thiserror = "1.0"
 #[dependencies.zeroize]
 #version = "1.2.0"
 #features = ["zeroize_derive"]
+
 bs58 = "0.4.0"
 sha2 = "0.9"
 sha3 = "0.9"
 
 [dependencies.ff]
-version = "0.9"
+version = "0.10"
 default-features = false
 
 [dependencies.group]
-version = "0.9"
+version = "0.10"
 default-features = false
 
 [dev-dependencies]

--- a/coconut-rs/Cargo.toml
+++ b/coconut-rs/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bls12_381 = "0.5"
+bls12_381 = "0.4"
 itertools = "0.10"
 digest = "0.9"
 rand = "0.8"
@@ -16,16 +16,16 @@ thiserror = "1.0"
 #[dependencies.zeroize]
 #version = "1.2.0"
 #features = ["zeroize_derive"]
-
+bs58 = "0.4.0"
 sha2 = "0.9"
 sha3 = "0.9"
 
 [dependencies.ff]
-version = "0.10"
+version = "0.9"
 default-features = false
 
 [dependencies.group]
-version = "0.10"
+version = "0.9"
 default-features = false
 
 [dev-dependencies]

--- a/coconut-rs/Cargo.toml
+++ b/coconut-rs/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bls12_381 = "0.5"
+bls12_381 = {version = "0.5", default-features = false, features = ["pairings", "alloc"]}
 itertools = "0.10"
 digest = "0.9"
 rand = "0.8"

--- a/coconut-rs/src/elgamal.rs
+++ b/coconut-rs/src/elgamal.rs
@@ -153,8 +153,8 @@ impl Bytable for PublicKey {
         self.0.to_affine().to_compressed().into()
     }
 
-    fn from_byte_slice(slice: &[u8]) -> Self {
-        PublicKey::from_bytes(slice.try_into().unwrap()).unwrap()
+    fn try_from_byte_slice(slice: &[u8]) -> Result<Self> {
+        Ok(PublicKey::from_bytes(slice.try_into().unwrap()).unwrap())
     }
 }
 

--- a/coconut-rs/src/elgamal.rs
+++ b/coconut-rs/src/elgamal.rs
@@ -14,17 +14,13 @@
 
 use crate::error::{CoconutError, Result};
 use crate::scheme::setup::Parameters;
+use crate::traits::{Base58, Bytable};
 use crate::utils::{try_deserialize_g1_projective, try_deserialize_scalar};
 use bls12_381::{G1Projective, Scalar};
 use core::ops::{Deref, Mul};
 use group::Curve;
 use std::convert::TryFrom;
 use std::convert::TryInto;
-
-#[cfg(feature = "serde")]
-use serde::de::Visitor;
-#[cfg(feature = "serde")]
-use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
 
 /// Type alias for the ephemeral key generated during ElGamal encryption
 pub type EphemeralKey = Scalar;
@@ -144,12 +140,30 @@ impl PublicKey {
     }
 
     pub fn to_bytes(&self) -> [u8; 48] {
-        self.0.to_affine().to_compressed()
+        self.to_byte_vec().try_into().unwrap()
     }
 
     pub fn from_bytes(bytes: &[u8; 48]) -> Result<PublicKey> {
+        Ok(PublicKey::try_from(bytes.to_vec().as_slice()).unwrap())
+    }
+}
+
+impl Bytable for PublicKey {
+    fn to_byte_vec(&self) -> Vec<u8> {
+        self.0.to_affine().to_compressed().into()
+    }
+
+    fn from_byte_slice(slice: &[u8]) -> Self {
+        PublicKey::from_bytes(slice.try_into().unwrap()).unwrap()
+    }
+}
+
+impl TryFrom<&[u8]> for PublicKey {
+    type Error = CoconutError;
+
+    fn try_from(slice: &[u8]) -> Result<PublicKey> {
         try_deserialize_g1_projective(
-            bytes,
+            slice.try_into().unwrap(),
             CoconutError::Deserialization(
                 "Failed to deserialize compressed ElGamal public key".to_string(),
             ),
@@ -157,6 +171,8 @@ impl PublicKey {
         .map(PublicKey)
     }
 }
+
+impl Base58 for PublicKey {}
 
 impl Deref for PublicKey {
     type Target = G1Projective;
@@ -200,172 +216,6 @@ pub fn elgamal_keygen(params: &Parameters) -> ElGamalKeyPair {
         public_key: PublicKey(gamma),
     }
 }
-
-#[cfg(feature = "serde")]
-impl Serialize for PrivateKey {
-    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        use serde::ser::SerializeTuple;
-        let mut tup = serializer.serialize_tuple(32)?;
-        for byte in self.to_bytes().iter() {
-            tup.serialize_element(byte)?;
-        }
-        tup.end()
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> Deserialize<'de> for PrivateKey {
-    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct PrivateKeyVisitor;
-
-        impl<'de> Visitor<'de> for PrivateKeyVisitor {
-            type Value = PrivateKey;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
-                formatter.write_str("a 32-byte ElGamal private key on BLS12_381 curve")
-            }
-
-            fn visit_seq<A>(self, mut seq: A) -> core::result::Result<PrivateKey, A::Error>
-            where
-                A: serde::de::SeqAccess<'de>,
-            {
-                let mut bytes = [0u8; 32];
-                // I think this way makes it way more readable than the iterator approach
-                #[allow(clippy::needless_range_loop)]
-                for i in 0..32 {
-                    bytes[i] = seq
-                        .next_element()?
-                        .ok_or_else(|| serde::de::Error::invalid_length(i, &"expected 32 bytes"))?;
-                }
-
-                PrivateKey::from_bytes(&bytes).map_err(|_| {
-                    serde::de::Error::custom(&"private key scalar was not canonically encoded")
-                })
-            }
-        }
-
-        deserializer.deserialize_tuple(32, PrivateKeyVisitor)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl Serialize for PublicKey {
-    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        use serde::ser::SerializeTuple;
-        let mut tup = serializer.serialize_tuple(48)?;
-        for byte in self.to_bytes().iter() {
-            tup.serialize_element(byte)?;
-        }
-        tup.end()
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> Deserialize<'de> for PublicKey {
-    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct PublicKeyVisitor;
-
-        impl<'de> Visitor<'de> for PublicKeyVisitor {
-            type Value = PublicKey;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
-                formatter.write_str("a 48-byte compressed ElGamal public key on BLS12_381 curve")
-            }
-
-            fn visit_seq<A>(self, mut seq: A) -> core::result::Result<PublicKey, A::Error>
-            where
-                A: serde::de::SeqAccess<'de>,
-            {
-                let mut bytes = [0u8; 48];
-                // I think this way makes it way more readable than the iterator approach
-                #[allow(clippy::needless_range_loop)]
-                for i in 0..48 {
-                    bytes[i] = seq
-                        .next_element()?
-                        .ok_or_else(|| serde::de::Error::invalid_length(i, &"expected 48 bytes"))?;
-                }
-
-                PublicKey::from_bytes(&bytes).map_err(|_| {
-                    serde::de::Error::custom(
-                        &"public key G1 curve point was not canonically encoded",
-                    )
-                })
-            }
-        }
-
-        deserializer.deserialize_tuple(48, PublicKeyVisitor)
-    }
-}
-
-// TODO: I think that is wrong and should rather serialize both elements separately
-//
-// #[cfg(feature = "serde")]
-// impl Serialize for Ciphertext {
-//     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
-//     where
-//         S: Serializer,
-//     {
-//         use serde::ser::SerializeTuple;
-//         let mut tup = serializer.serialize_tuple(96)?;
-//         for byte in self.to_bytes().iter() {
-//             tup.serialize_element(byte)?;
-//         }
-//         tup.end()
-//     }
-// }
-//
-// #[cfg(feature = "serde")]
-// impl<'de> Deserialize<'de> for Ciphertext {
-//     fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
-//     where
-//         D: Deserializer<'de>,
-//     {
-//         struct CiphertextVisitor;
-//
-//         impl<'de> Visitor<'de> for CiphertextVisitor {
-//             type Value = Ciphertext;
-//
-//             fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
-//                 formatter.write_str("a 96-byte ElGamal ciphertext consisting of two compressed G1 points on BLS12_381 curve")
-//             }
-//
-//             fn visit_seq<A>(self, mut seq: A) -> core::result::Result<Ciphertext, A::Error>
-//             where
-//                 A: serde::de::SeqAccess<'de>,
-//             {
-//                 let mut bytes = [0u8; 96];
-//                 // I think this way makes it way more readable than the iterator approach
-//                 #[allow(clippy::needless_range_loop)]
-//                 for i in 0..96 {
-//                     bytes[i] = seq
-//                         .next_element()?
-//                         .ok_or_else(|| serde::de::Error::invalid_length(i, &"expected 96 bytes"))?;
-//                 }
-//
-//                 Ciphertext::from_bytes(&bytes).map_err(|_| {
-//                     serde::de::Error::custom(
-//                         &"the ciphertext G1 curve points were not canonically encoded",
-//                     )
-//                 })
-//             }
-//         }
-//
-//         deserializer.deserialize_tuple(96, CiphertextVisitor)
-//     }
-// }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/coconut-rs/src/lib.rs
+++ b/coconut-rs/src/lib.rs
@@ -14,6 +14,7 @@
 
 use bls12_381::Scalar;
 use sha3::Sha3_384;
+use std::convert::TryInto;
 
 pub mod elgamal;
 mod error;
@@ -21,10 +22,13 @@ mod proofs;
 mod scheme;
 #[cfg(test)]
 mod tests;
+mod traits;
 mod utils;
 
+use crate::traits::Bytable;
 pub use elgamal::elgamal_keygen;
 pub use elgamal::ElGamalKeyPair;
+pub use elgamal::PublicKey;
 pub use error::CoconutError;
 pub use scheme::aggregation::aggregate_signature_shares;
 pub use scheme::aggregation::aggregate_verification_keys;
@@ -41,8 +45,21 @@ pub use scheme::verification::verify_credential;
 pub use scheme::BlindedSignature;
 pub use scheme::Signature;
 pub use scheme::SignatureShare;
+pub use traits::Base58;
 
 pub type Attribute = Scalar;
+
+impl Bytable for Attribute {
+    fn to_byte_vec(&self) -> Vec<u8> {
+        self.to_bytes().to_vec()
+    }
+
+    fn from_byte_slice(slice: &[u8]) -> Self {
+        Attribute::from_bytes(slice.try_into().unwrap()).unwrap()
+    }
+}
+
+impl Base58 for Attribute {}
 
 // reason for sha3 384 is for the 48 bytes output and it's a good enough solution
 // for the temporary use it has

--- a/coconut-rs/src/lib.rs
+++ b/coconut-rs/src/lib.rs
@@ -54,8 +54,8 @@ impl Bytable for Attribute {
         self.to_bytes().to_vec()
     }
 
-    fn from_byte_slice(slice: &[u8]) -> Self {
-        Attribute::from_bytes(slice.try_into().unwrap()).unwrap()
+    fn try_from_byte_slice(slice: &[u8]) -> Result<Self, CoconutError> {
+        Ok(Attribute::from_bytes(slice.try_into().unwrap()).unwrap())
     }
 }
 

--- a/coconut-rs/src/scheme/issuance.rs
+++ b/coconut-rs/src/scheme/issuance.rs
@@ -102,8 +102,8 @@ impl Bytable for BlindSignRequest {
         bytes
     }
 
-    fn from_byte_slice(slice: &[u8]) -> Self {
-        BlindSignRequest::from_bytes(slice).unwrap()
+    fn try_from_byte_slice(slice: &[u8]) -> Result<Self> {
+        BlindSignRequest::from_bytes(slice)
     }
 }
 

--- a/coconut-rs/src/scheme/mod.rs
+++ b/coconut-rs/src/scheme/mod.rs
@@ -109,8 +109,8 @@ impl Bytable for BlindedSignature {
         self.to_bytes().to_vec()
     }
 
-    fn from_byte_slice(slice: &[u8]) -> Self {
-        Self::from_bytes(slice).unwrap()
+    fn try_from_byte_slice(slice: &[u8]) -> Result<Self> {
+        Self::from_bytes(slice)
     }
 }
 

--- a/coconut-rs/src/scheme/mod.rs
+++ b/coconut-rs/src/scheme/mod.rs
@@ -19,6 +19,7 @@ use crate::elgamal::Ciphertext;
 use crate::error::{CoconutError, Result};
 use crate::scheme::aggregation::{aggregate_signature_shares, aggregate_signatures};
 use crate::scheme::setup::Parameters;
+use crate::traits::{Base58, Bytable};
 use crate::utils::try_deserialize_g1_projective;
 use bls12_381::G1Projective;
 use group::Curve;
@@ -102,6 +103,18 @@ impl Signature {
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct BlindedSignature(G1Projective, elgamal::Ciphertext);
+
+impl Bytable for BlindedSignature {
+    fn to_byte_vec(&self) -> Vec<u8> {
+        self.to_bytes().to_vec()
+    }
+
+    fn from_byte_slice(slice: &[u8]) -> Self {
+        Self::from_bytes(slice).unwrap()
+    }
+}
+
+impl Base58 for BlindedSignature {}
 
 impl TryFrom<&[u8]> for BlindedSignature {
     type Error = CoconutError;

--- a/coconut-rs/src/traits.rs
+++ b/coconut-rs/src/traits.rs
@@ -1,0 +1,17 @@
+pub trait Bytable {
+    fn to_byte_vec(&self) -> Vec<u8>;
+
+    fn from_byte_slice(slice: &[u8]) -> Self;
+}
+
+pub trait Base58
+where
+    Self: Bytable + Sized,
+{
+    fn from_bs58(x: &str) -> Self {
+        Self::from_byte_slice(&bs58::decode(x).into_vec().unwrap())
+    }
+    fn to_bs58(&self) -> String {
+        bs58::encode(self.to_byte_vec()).into_string()
+    }
+}

--- a/coconut-rs/src/traits.rs
+++ b/coconut-rs/src/traits.rs
@@ -13,8 +13,8 @@ pub trait Base58
 where
     Self: Bytable,
 {
-    fn try_from_bs58(x: &str) -> Result<Self, CoconutError> {
-        Self::try_from_byte_slice(&bs58::decode(x).into_vec().unwrap())
+    fn try_from_bs58<S: AsRef<str>>(x: S) -> Result<Self, CoconutError> {
+        Self::try_from_byte_slice(&bs58::decode(x.as_ref()).into_vec().unwrap())
     }
     fn to_bs58(&self) -> String {
         bs58::encode(self.to_byte_vec()).into_string()

--- a/coconut-rs/src/traits.rs
+++ b/coconut-rs/src/traits.rs
@@ -1,15 +1,20 @@
-pub trait Bytable {
+use crate::CoconutError;
+
+pub trait Bytable
+where
+    Self: Sized,
+{
     fn to_byte_vec(&self) -> Vec<u8>;
 
-    fn from_byte_slice(slice: &[u8]) -> Self;
+    fn try_from_byte_slice(slice: &[u8]) -> Result<Self, CoconutError>;
 }
 
 pub trait Base58
 where
-    Self: Bytable + Sized,
+    Self: Bytable,
 {
-    fn from_bs58(x: &str) -> Self {
-        Self::from_byte_slice(&bs58::decode(x).into_vec().unwrap())
+    fn try_from_bs58(x: &str) -> Result<Self, CoconutError> {
+        Self::try_from_byte_slice(&bs58::decode(x).into_vec().unwrap())
     }
     fn to_bs58(&self) -> String {
         bs58::encode(self.to_byte_vec()).into_string()


### PR DESCRIPTION
+ Introduce a `Base58` trait until we get proper `SerDe` support.
+ Introduces a `Bytable` trait so we can `impl Base58` for out of crate types

We'll do a cleanup round after we integrate coconut into validator-api, for now this provides a pretty clean serde interface