### PR TITLE
Nym coconut credentials

### DIFF
--- a/coconut-rs/README.md
+++ b/coconut-rs/README.md
@@ -53,7 +53,7 @@ fn main() -> Result<(), CoconutError> {
     let unblinded_signatures: Vec<Signature> = blinded_signatures
         .into_iter()
         .zip(verification_keys.iter())
-        .map(|(signature, verification_key)| signature.unblind(&params, &elgamal_keypair.private_key(), &verification_key, &private_attributes, &public_attributes).unwrap())
+        .map(|(signature, verification_key)| signature.unblind(&params, &elgamal_keypair.private_key(), &verification_key, &private_attributes, &public_attributes, blind_sign_request.commitment_hash).unwrap())
         .collect();
 
     // Aggregate signatures

--- a/coconut-rs/README.md
+++ b/coconut-rs/README.md
@@ -13,6 +13,10 @@ fn main() -> Result<(), CoconutError> {
     let public_attributes = params.n_random_scalars(2);
     let private_attributes = params.n_random_scalars(3);
 
+    let mut attributes = Vec::with_capacity(private_attributes.len() + public_attributes.len());
+    attributes.extend_from_slice(&private_attributes);
+    attributes.extend_from_slice(&public_attributes);
+
     let elgamal_keypair = elgamal_keygen(&params);
 
     // generate commitment and encryption
@@ -64,7 +68,7 @@ fn main() -> Result<(), CoconutError> {
         .map(|(idx, signature)| SignatureShare::new(*signature, (idx + 1) as u64))
         .collect();
 
-    let signature = aggregate_signature_shares(&signature_shares)?;
+    let signature = aggregate_signature_shares(&params, &verification_key, &attributes, &signature_shares)?;
 
     // Randomize credentials and generate any cryptographic material to verify them
 

--- a/coconut-rs/README.md
+++ b/coconut-rs/README.md
@@ -18,7 +18,7 @@ fn main() -> Result<(), CoconutError> {
     // generate commitment and encryption
     let blind_sign_request = prepare_blind_sign(
         &params,
-        &elgamal_keypair.public_key(),
+        &elgamal_keypair,
         &private_attributes,
         &public_attributes,
     )?;
@@ -32,7 +32,7 @@ fn main() -> Result<(), CoconutError> {
         .collect();
 
     // aggregate verification keys
-    let verification_key = aggregate_verification_keys(&verification_keys, Some(&[1,2,3]))?;
+    let verification_key = aggregate_verification_keys(&verification_keys, Some(&[1, 2, 3]))?;
 
     // generate blinded signatures
     let mut blinded_signatures = Vec::new();
@@ -108,7 +108,6 @@ fn main() -> Result<(), CoconutError> {
 | unblind_prove_and_verify_10_authorities_10_attributes   | 129.69 ms | 130.46 ms | 131.37 ms |
 | unblind_prove_and_verify_100_authorities_1_attributes   | 1.0216 s  | 1.0237 s  | 1.0261 s  |
 | unblind_prove_and_verify_200_authorities_1_attributes   | 2.2503 s  | 2.2621 s  | 2.2740 s  |
-
 
 ## References
 

--- a/coconut-rs/README.md
+++ b/coconut-rs/README.md
@@ -52,7 +52,8 @@ fn main() -> Result<(), CoconutError> {
 
     let unblinded_signatures: Vec<Signature> = blinded_signatures
         .into_iter()
-        .map(|signature| signature.unblind(&elgamal_keypair.private_key()))
+        .zip(verification_keys.iter())
+        .map(|(signature, verification_key)| signature.unblind(&params, &elgamal_keypair.private_key(), &verification_key, &private_attributes, &public_attributes).unwrap())
         .collect();
 
     // Aggregate signatures

--- a/coconut-rs/src/elgamal.rs
+++ b/coconut-rs/src/elgamal.rs
@@ -12,16 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::ops::{Deref, Mul};
+use std::convert::TryFrom;
+use std::convert::TryInto;
+
+use bls12_381::{G1Projective, Scalar};
+use group::Curve;
+use serde_derive::{Deserialize, Serialize};
+
 use crate::error::{CoconutError, Result};
 use crate::scheme::setup::Parameters;
 use crate::traits::{Base58, Bytable};
 use crate::utils::{try_deserialize_g1_projective, try_deserialize_scalar};
-use bls12_381::{G1Projective, Scalar};
-use core::ops::{Deref, Mul};
-use group::Curve;
-use serde_derive::{Deserialize, Serialize};
-use std::convert::TryFrom;
-use std::convert::TryInto;
 
 /// Type alias for the ephemeral key generated during ElGamal encryption
 pub type EphemeralKey = Scalar;
@@ -82,7 +84,7 @@ impl Ciphertext {
 /// PrivateKey used in the ElGamal encryption scheme to recover the plaintext
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq))]
-pub struct PrivateKey(Scalar);
+pub struct PrivateKey(pub(crate) Scalar);
 
 impl PrivateKey {
     /// Decrypt takes the ElGamal encryption of a message and returns a point on the G1 curve
@@ -110,7 +112,7 @@ impl PrivateKey {
                     .to_string(),
             ),
         )
-        .map(PrivateKey)
+            .map(PrivateKey)
     }
 }
 
@@ -181,7 +183,7 @@ impl TryFrom<&[u8]> for PublicKey {
                 "Failed to deserialize compressed ElGamal public key".to_string(),
             ),
         )
-        .map(PublicKey)
+            .map(PublicKey)
     }
 }
 
@@ -230,6 +232,7 @@ pub fn elgamal_keygen(params: &Parameters) -> ElGamalKeyPair {
         public_key: PublicKey(gamma),
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -323,7 +326,7 @@ mod tests {
             ciphertext.0.to_affine().to_compressed(),
             ciphertext.1.to_affine().to_compressed(),
         ]
-        .concat();
+            .concat();
         assert_eq!(expected_bytes, bytes);
         assert_eq!(ciphertext, Ciphertext::try_from(&bytes[..]).unwrap())
     }

--- a/coconut-rs/src/error.rs
+++ b/coconut-rs/src/error.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use thiserror::Error;
+
 /// A `Result` alias where the `Err` case is `coconut_rs::Error`.
 pub type Result<T> = std::result::Result<T, CoconutError>;
 
@@ -30,14 +31,16 @@ pub enum CoconutError {
     Interpolation(String),
     #[error("Aggregation error: {0}")]
     Aggregation(String),
+    #[error("Unblind error: {0}")]
+    Unblind(String),
     #[error("Verification error: {0}")]
     Verification(String),
     #[error("Deserialization error: {0}")]
     Deserialization(String),
     #[error(
-        "Deserailization error, expected at least {} bytes, got {}",
-        min,
-        actual
+    "Deserailization error, expected at least {} bytes, got {}",
+    min,
+    actual
     )]
     DeserializationMinLength { min: usize, actual: usize },
     #[error("Tried to deserialize {object} with bytes of invalid length. Expected {actual} < {} or {modulus_target} % {modulus} == 0")]

--- a/coconut-rs/src/proofs/mod.rs
+++ b/coconut-rs/src/proofs/mod.rs
@@ -18,18 +18,18 @@ use std::borrow::Borrow;
 use std::convert::TryInto;
 
 use bls12_381::{G1Projective, G2Projective, Scalar};
-use digest::Digest;
 use digest::generic_array::typenum::Unsigned;
+use digest::Digest;
 use group::GroupEncoding;
 use itertools::izip;
 use sha2::Sha256;
 
-use crate::{Attribute, elgamal, ElGamalKeyPair, PublicKey};
 use crate::elgamal::Ciphertext;
 use crate::error::{CoconutError, Result};
-use crate::scheme::{Signature, VerificationKey};
 use crate::scheme::setup::Parameters;
+use crate::scheme::{Signature, VerificationKey};
 use crate::utils::{hash_g1, try_deserialize_scalar, try_deserialize_scalar_vec};
+use crate::{elgamal, Attribute, ElGamalKeyPair, PublicKey};
 
 // as per the reference python implementation
 type ChallengeDigest = Sha256;
@@ -51,10 +51,10 @@ pub struct ProofCmCs {
 // and as per the bls12-381 library all elements are using big-endian form
 /// Generates a Scalar [or Fp] challenge by hashing a number of elliptic curve points.  
 fn compute_challenge<D, I, B>(iter: I) -> Scalar
-    where
-        D: Digest,
-        I: Iterator<Item=B>,
-        B: AsRef<[u8]>,
+where
+    D: Digest,
+    I: Iterator<Item = B>,
+    B: AsRef<[u8]>,
 {
     let mut h = D::new();
     for point_representation in iter {
@@ -82,8 +82,8 @@ fn produce_response(witness: &Scalar, challenge: &Scalar, secret: &Scalar) -> Sc
 
 // note: it's caller's responsibility to ensure witnesses.len() = secrets.len()
 fn produce_responses<S>(witnesses: &[Scalar], challenge: &Scalar, secrets: &[S]) -> Vec<Scalar>
-    where
-        S: Borrow<Scalar>,
+where
+    S: Borrow<Scalar>,
 {
     debug_assert_eq!(witnesses.len(), secrets.len());
 
@@ -116,8 +116,7 @@ impl ProofCmCs {
         let witness_commitment_opening = params.random_scalar();
         let witness_private_elgamal_key = params.random_scalar();
         let witness_keys = params.n_random_scalars(ephemeral_keys.len());
-        let witness_attributes =
-            params.n_random_scalars(private_attributes.len());
+        let witness_attributes = params.n_random_scalars(private_attributes.len());
 
         // recompute h
         let h = hash_g1(commitment.to_bytes());
@@ -151,36 +150,47 @@ impl ProofCmCs {
         // Ccm = (wr * g1) + (wm[0] * hs[0]) + ... + (wm[i] * hs[i])
         let commitment_attributes = g1 * witness_commitment_opening
             + witness_attributes
-            .iter()
-            .zip(params.gen_hs().iter())
-            .map(|(wm_i, hs_i)| hs_i * wm_i)
-            .sum::<G1Projective>();
+                .iter()
+                .zip(params.gen_hs().iter())
+                .map(|(wm_i, hs_i)| hs_i * wm_i)
+                .sum::<G1Projective>();
 
+        let ciphertexts_bytes = priv_attributes_ciphertexts
+            .iter()
+            .map(|c| c.to_bytes())
+            .collect::<Vec<_>>();
 
         // compute challenge
         let challenge = compute_challenge::<ChallengeDigest, _, _>(
             std::iter::once(params.gen1().to_bytes().as_ref())
                 .chain(hs_bytes.iter().map(|hs| hs.as_ref()))
                 .chain(std::iter::once(h.to_bytes().as_ref()))
-                .chain(std::iter::once(elgamal_keypair.public_key().to_bytes().as_ref()))
+                .chain(std::iter::once(
+                    elgamal_keypair.public_key().to_bytes().as_ref(),
+                ))
                 .chain(std::iter::once(commitment.to_bytes().as_ref()))
                 .chain(std::iter::once(commitment_attributes.to_bytes().as_ref()))
-                .chain(std::iter::once(commitment_private_key_elgamal.to_bytes().as_ref()))
+                .chain(std::iter::once(
+                    commitment_private_key_elgamal.to_bytes().as_ref(),
+                ))
                 .chain(commitment_keys1_bytes.iter().map(|aw| aw.as_ref()))
                 .chain(commitment_keys2_bytes.iter().map(|bw| bw.as_ref()))
-                .chain(priv_attributes_ciphertexts.iter().map(|c| c.to_bytes().as_ref())),
+                .chain(ciphertexts_bytes.iter().map(|c| c.as_ref())),
         );
 
         // Responses
-        let response_opening = produce_response(&witness_commitment_opening, &challenge, &commitment_opening);
-        let response_private_elgamal_key = produce_response(&witness_private_elgamal_key, &challenge, &elgamal_keypair.private_key().0);
+        let response_opening =
+            produce_response(&witness_commitment_opening, &challenge, &commitment_opening);
+        let response_private_elgamal_key = produce_response(
+            &witness_private_elgamal_key,
+            &challenge,
+            &elgamal_keypair.private_key().0,
+        );
         let response_keys = produce_responses(&witness_keys, &challenge, ephemeral_keys);
         let response_attributes = produce_responses(
             &witness_attributes,
             &challenge,
-            &private_attributes
-                .iter()
-                .collect::<Vec<_>>(),
+            &private_attributes.iter().collect::<Vec<_>>(),
         );
 
         ProofCmCs {
@@ -214,7 +224,8 @@ impl ProofCmCs {
             .collect::<Vec<_>>();
 
         // recompute witnesses commitments
-        let commitment_private_key_elgamal = pub_key * &self.challenge + g1 * self.response_private_elgamal_key;
+        let commitment_private_key_elgamal =
+            pub_key * &self.challenge + g1 * self.response_private_elgamal_key;
 
         // Aw[i] = (c * c1[i]) + (rk[i] * g1)
         let commitment_keys1_bytes = attributes_ciphertexts
@@ -233,18 +244,19 @@ impl ProofCmCs {
             self.response_keys.iter(),
             self.response_attributes.iter()
         )
-            .map(|(c2, res_key, res_attr)| c2 * self.challenge + pub_key * res_key + h * res_attr)
-            .map(|witness| witness.to_bytes())
-            .collect::<Vec<_>>();
+        .map(|(c2, res_key, res_attr)| c2 * self.challenge + pub_key * res_key + h * res_attr)
+        .map(|witness| witness.to_bytes())
+        .collect::<Vec<_>>();
 
         // Cw = (cm * c) + (rr * g1) + (rm[0] * hs[0]) + ... + (rm[n] * hs[n])
         let commitment_attributes = commitment * self.challenge
             + g1 * self.response_opening
-            + self.response_attributes
-            .iter()
-            .zip(params.gen_hs().iter())
-            .map(|(res_attr, hs)| hs * res_attr)
-            .sum::<G1Projective>();
+            + self
+                .response_attributes
+                .iter()
+                .zip(params.gen_hs().iter())
+                .map(|(res_attr, hs)| hs * res_attr)
+                .sum::<G1Projective>();
 
         // re-compute the challenge
         let challenge = compute_challenge::<ChallengeDigest, _, _>(
@@ -254,7 +266,9 @@ impl ProofCmCs {
                 .chain(std::iter::once(pub_key.to_bytes().as_ref()))
                 .chain(std::iter::once(commitment.to_bytes().as_ref()))
                 .chain(std::iter::once(commitment_attributes.to_bytes().as_ref()))
-                .chain(std::iter::once(commitment_private_key_elgamal.to_bytes().as_ref()))
+                .chain(std::iter::once(
+                    commitment_private_key_elgamal.to_bytes().as_ref(),
+                ))
                 .chain(commitment_keys1_bytes.iter().map(|aw| aw.as_ref()))
                 .chain(commitment_keys2_bytes.iter().map(|bw| bw.as_ref())),
         );
@@ -391,11 +405,10 @@ impl ProofKappaNu {
         let commitment_kappa = params.gen2() * witness_blinder
             + verification_key.alpha
             + witness_attributes
-            .iter()
-            .zip(verification_key.beta.iter())
-            .map(|(wm_i, beta_i)| beta_i * wm_i)
-            .sum::<G2Projective>();
-
+                .iter()
+                .zip(verification_key.beta.iter())
+                .map(|(wm_i, beta_i)| beta_i * wm_i)
+                .sum::<G2Projective>();
 
         let challenge = compute_challenge::<ChallengeDigest, _, _>(
             std::iter::once(params.gen2().to_bytes().as_ref())
@@ -439,11 +452,11 @@ impl ProofKappaNu {
             + params.gen2() * self.response_blinder
             + verification_key.alpha * (Scalar::one() - self.challenge)
             + self
-            .response_attributes
-            .iter()
-            .zip(verification_key.beta.iter())
-            .map(|(priv_attr, beta_i)| beta_i * priv_attr)
-            .sum::<G2Projective>();
+                .response_attributes
+                .iter()
+                .zip(verification_key.beta.iter())
+                .map(|(priv_attr, beta_i)| beta_i * priv_attr)
+                .sum::<G2Projective>();
 
         // Bw = (c * nu) + (rt * h)
         // let commitment_blinder = nu * self.challenge + signature.sig1() * self.response_blinder;
@@ -557,7 +570,13 @@ mod tests {
         let r = params.random_scalar();
 
         let commitment_hash = compute_commitment_hash(cm);
-        let (attributes_ciphertexts, ephemeral_keys): (Vec<_>, Vec<_>) = compute_attribute_encryption(&params, private_attributes.as_ref(), elgamal_keypair.public_key(), commitment_hash);
+        let (attributes_ciphertexts, ephemeral_keys): (Vec<_>, Vec<_>) =
+            compute_attribute_encryption(
+                &params,
+                private_attributes.as_ref(),
+                elgamal_keypair.public_key(),
+                commitment_hash,
+            );
         let ephemeral_keys = params.n_random_scalars(1);
 
         // 0 public 1 private

--- a/coconut-rs/src/proofs/mod.rs
+++ b/coconut-rs/src/proofs/mod.rs
@@ -411,7 +411,7 @@ impl ProofKappaNu {
                 .chain(std::iter::once(params.gen2().to_bytes().as_ref()))
                 .chain(std::iter::once(verification_key.alpha.to_bytes().as_ref()))
                 .chain(std::iter::once(commitment_kappa.to_bytes().as_ref()))
-                .chain(std::iter::once(commitment_blinder.to_bytes().as_ref()))
+                // .chain(std::iter::once(commitment_blinder.to_bytes().as_ref()))
                 .chain(hs_bytes.iter().map(|hs| hs.as_ref()))
                 .chain(beta_bytes.iter().map(|b| b.as_ref())),
         );
@@ -439,7 +439,6 @@ impl ProofKappaNu {
         signature: &Signature,
         // TODO NAMING: kappa, nu...
         kappa: &G2Projective,
-        nu: &G1Projective,
     ) -> bool {
         let hs_bytes = params
             .gen_hs()
@@ -467,7 +466,7 @@ impl ProofKappaNu {
             .sum::<G2Projective>();
 
         // Bw = (c * nu) + (rt * h)
-        let commitment_blinder = nu * self.challenge + signature.sig1() * self.response_blinder;
+        // let commitment_blinder = nu * self.challenge + signature.sig1() * self.response_blinder;
 
         // compute the challenge prime ([g1, g2, alpha, Aw, Bw]+hs+beta)
         let challenge = compute_challenge::<ChallengeDigest, _, _>(
@@ -475,7 +474,7 @@ impl ProofKappaNu {
                 .chain(std::iter::once(params.gen2().to_bytes().as_ref()))
                 .chain(std::iter::once(verification_key.alpha.to_bytes().as_ref()))
                 .chain(std::iter::once(commitment_kappa.to_bytes().as_ref()))
-                .chain(std::iter::once(commitment_blinder.to_bytes().as_ref()))
+                // .chain(std::iter::once(commitment_blinder.to_bytes().as_ref()))
                 .chain(hs_bytes.iter().map(|hs| hs.as_ref()))
                 .chain(beta_bytes.iter().map(|b| b.as_ref())),
         );

--- a/coconut-rs/src/proofs/mod.rs
+++ b/coconut-rs/src/proofs/mod.rs
@@ -18,18 +18,18 @@ use std::borrow::Borrow;
 use std::convert::TryInto;
 
 use bls12_381::{G1Projective, G2Projective, Scalar};
-use digest::generic_array::typenum::Unsigned;
 use digest::Digest;
+use digest::generic_array::typenum::Unsigned;
 use group::GroupEncoding;
 use itertools::izip;
 use sha2::Sha256;
 
+use crate::{Attribute, elgamal, ElGamalKeyPair, PublicKey};
 use crate::elgamal::Ciphertext;
 use crate::error::{CoconutError, Result};
-use crate::scheme::setup::Parameters;
 use crate::scheme::{Signature, VerificationKey};
+use crate::scheme::setup::Parameters;
 use crate::utils::{hash_g1, try_deserialize_scalar, try_deserialize_scalar_vec};
-use crate::{elgamal, Attribute, ElGamalKeyPair, PublicKey};
 
 // as per the reference python implementation
 type ChallengeDigest = Sha256;
@@ -51,10 +51,10 @@ pub struct ProofCmCs {
 // and as per the bls12-381 library all elements are using big-endian form
 /// Generates a Scalar [or Fp] challenge by hashing a number of elliptic curve points.  
 fn compute_challenge<D, I, B>(iter: I) -> Scalar
-where
-    D: Digest,
-    I: Iterator<Item = B>,
-    B: AsRef<[u8]>,
+    where
+        D: Digest,
+        I: Iterator<Item=B>,
+        B: AsRef<[u8]>,
 {
     let mut h = D::new();
     for point_representation in iter {
@@ -82,8 +82,8 @@ fn produce_response(witness: &Scalar, challenge: &Scalar, secret: &Scalar) -> Sc
 
 // note: it's caller's responsibility to ensure witnesses.len() = secrets.len()
 fn produce_responses<S>(witnesses: &[Scalar], challenge: &Scalar, secrets: &[S]) -> Vec<Scalar>
-where
-    S: Borrow<Scalar>,
+    where
+        S: Borrow<Scalar>,
 {
     debug_assert_eq!(witnesses.len(), secrets.len());
 
@@ -150,10 +150,10 @@ impl ProofCmCs {
         // Ccm = (wr * g1) + (wm[0] * hs[0]) + ... + (wm[i] * hs[i])
         let commitment_attributes = g1 * witness_commitment_opening
             + witness_attributes
-                .iter()
-                .zip(params.gen_hs().iter())
-                .map(|(wm_i, hs_i)| hs_i * wm_i)
-                .sum::<G1Projective>();
+            .iter()
+            .zip(params.gen_hs().iter())
+            .map(|(wm_i, hs_i)| hs_i * wm_i)
+            .sum::<G1Projective>();
 
         let ciphertexts_bytes = priv_attributes_ciphertexts
             .iter()
@@ -244,19 +244,24 @@ impl ProofCmCs {
             self.response_keys.iter(),
             self.response_attributes.iter()
         )
-        .map(|(c2, res_key, res_attr)| c2 * self.challenge + pub_key * res_key + h * res_attr)
-        .map(|witness| witness.to_bytes())
-        .collect::<Vec<_>>();
+            .map(|(c2, res_key, res_attr)| c2 * self.challenge + pub_key * res_key + h * res_attr)
+            .map(|witness| witness.to_bytes())
+            .collect::<Vec<_>>();
 
         // Cw = (cm * c) + (rr * g1) + (rm[0] * hs[0]) + ... + (rm[n] * hs[n])
         let commitment_attributes = commitment * self.challenge
             + g1 * self.response_opening
             + self
-                .response_attributes
-                .iter()
-                .zip(params.gen_hs().iter())
-                .map(|(res_attr, hs)| hs * res_attr)
-                .sum::<G1Projective>();
+            .response_attributes
+            .iter()
+            .zip(params.gen_hs().iter())
+            .map(|(res_attr, hs)| hs * res_attr)
+            .sum::<G1Projective>();
+
+        let ciphertexts_bytes = attributes_ciphertexts
+            .iter()
+            .map(|c| c.to_bytes())
+            .collect::<Vec<_>>();
 
         // re-compute the challenge
         let challenge = compute_challenge::<ChallengeDigest, _, _>(
@@ -270,7 +275,8 @@ impl ProofCmCs {
                     commitment_private_key_elgamal.to_bytes().as_ref(),
                 ))
                 .chain(commitment_keys1_bytes.iter().map(|aw| aw.as_ref()))
-                .chain(commitment_keys2_bytes.iter().map(|bw| bw.as_ref())),
+                .chain(commitment_keys2_bytes.iter().map(|bw| bw.as_ref()))
+                .chain(ciphertexts_bytes.iter().map(|c| c.as_ref())),
         );
 
         challenge == self.challenge
@@ -405,10 +411,10 @@ impl ProofKappaNu {
         let commitment_kappa = params.gen2() * witness_blinder
             + verification_key.alpha
             + witness_attributes
-                .iter()
-                .zip(verification_key.beta.iter())
-                .map(|(wm_i, beta_i)| beta_i * wm_i)
-                .sum::<G2Projective>();
+            .iter()
+            .zip(verification_key.beta.iter())
+            .map(|(wm_i, beta_i)| beta_i * wm_i)
+            .sum::<G2Projective>();
 
         let challenge = compute_challenge::<ChallengeDigest, _, _>(
             std::iter::once(params.gen2().to_bytes().as_ref())
@@ -452,11 +458,11 @@ impl ProofKappaNu {
             + params.gen2() * self.response_blinder
             + verification_key.alpha * (Scalar::one() - self.challenge)
             + self
-                .response_attributes
-                .iter()
-                .zip(verification_key.beta.iter())
-                .map(|(priv_attr, beta_i)| beta_i * priv_attr)
-                .sum::<G2Projective>();
+            .response_attributes
+            .iter()
+            .zip(verification_key.beta.iter())
+            .map(|(priv_attr, beta_i)| beta_i * priv_attr)
+            .sum::<G2Projective>();
 
         // Bw = (c * nu) + (rt * h)
         // let commitment_blinder = nu * self.challenge + signature.sig1() * self.response_blinder;

--- a/coconut-rs/src/proofs/mod.rs
+++ b/coconut-rs/src/proofs/mod.rs
@@ -156,6 +156,7 @@ impl ProofCmCs {
             .map(|(wm_i, hs_i)| hs_i * wm_i)
             .sum::<G1Projective>();
 
+
         // compute challenge
         let challenge = compute_challenge::<ChallengeDigest, _, _>(
             std::iter::once(params.gen1().to_bytes().as_ref())
@@ -166,7 +167,8 @@ impl ProofCmCs {
                 .chain(std::iter::once(commitment_attributes.to_bytes().as_ref()))
                 .chain(std::iter::once(commitment_private_key_elgamal.to_bytes().as_ref()))
                 .chain(commitment_keys1_bytes.iter().map(|aw| aw.as_ref()))
-                .chain(commitment_keys2_bytes.iter().map(|bw| bw.as_ref())),
+                .chain(commitment_keys2_bytes.iter().map(|bw| bw.as_ref()))
+                .chain(priv_attributes_ciphertexts.iter().map(|c| c.to_bytes().as_ref())),
         );
 
         // Responses
@@ -386,8 +388,6 @@ impl ProofKappaNu {
 
         // witnesses commitments
         // Aw = g2 * wt + alpha + beta[0] * wm[0] + ... + beta[i] * wm[i]
-        // TODO: kappa commitment??
-        // TODO NAMING: Aw, Bw
         let commitment_kappa = params.gen2() * witness_blinder
             + verification_key.alpha
             + witness_attributes

--- a/coconut-rs/src/scheme/aggregation.rs
+++ b/coconut-rs/src/scheme/aggregation.rs
@@ -12,13 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::error::{CoconutError, Result};
-use crate::scheme::{PartialSignature, Signature, SignatureShare, SignerIndex, VerificationKey};
-use crate::utils::perform_lagrangian_interpolation_at_origin;
-use bls12_381::Scalar;
 use core::iter::Sum;
 use core::ops::Mul;
+
+use bls12_381::{G2Prepared, G2Projective, Scalar};
+use group::Curve;
 use itertools::Itertools;
+
+use crate::{Attribute, Parameters};
+use crate::error::{CoconutError, Result};
+use crate::scheme::{PartialSignature, Signature, SignatureShare, SignerIndex, VerificationKey};
+use crate::scheme::verification::check_bilinear_pairing;
+use crate::utils::perform_lagrangian_interpolation_at_origin;
 
 pub(crate) trait Aggregatable: Sized {
     fn aggregate(aggregatable: &[Self], indices: Option<&[SignerIndex]>) -> Result<Self>;
@@ -31,10 +36,10 @@ pub(crate) trait Aggregatable: Sized {
 
 // includes `VerificationKey`
 impl<T> Aggregatable for T
-where
-    T: Sum,
-    for<'a> T: Sum<&'a T>,
-    for<'a> &'a T: Mul<Scalar, Output = T>,
+    where
+        T: Sum,
+        for<'a> T: Sum<&'a T>,
+        for<'a> &'a T: Mul<Scalar, Output=T>,
 {
     fn aggregate(aggregatable: &[T], indices: Option<&[u64]>) -> Result<T> {
         if aggregatable.is_empty() {
@@ -86,30 +91,61 @@ pub fn aggregate_verification_keys(
 }
 
 pub fn aggregate_signatures(
+    params: &Parameters,
+    verification_key: &VerificationKey,
+    attributes: &[Attribute],
     signatures: &[PartialSignature],
     indices: Option<&[SignerIndex]>,
 ) -> Result<Signature> {
-    Aggregatable::aggregate(signatures, indices)
+    let signature = match Aggregatable::aggregate(signatures, indices) {
+        Ok(res) => res,
+        Err(err) => return Err(err)
+    };
+
+    // Verify the signature
+    let alpha = verification_key.alpha;
+
+    let tmp = attributes.iter()
+        .zip(
+            verification_key
+                .beta
+                .iter())
+        .map(|(attr, beta_i)| beta_i * attr)
+        .sum::<G2Projective>();
+
+    if !check_bilinear_pairing(
+        &signature.0.to_affine(),
+        &G2Prepared::from((alpha + tmp).to_affine()),
+        &signature.1.to_affine(),
+        params.prepared_miller_g2(),
+    ) {
+        return Err(CoconutError::Aggregation(
+            "Verification of the aggregated signature failed".to_string(),
+        ));
+    }
+    Ok(signature)
 }
 
-pub fn aggregate_signature_shares(shares: &[SignatureShare]) -> Result<Signature> {
+pub fn aggregate_signature_shares(params: &Parameters, verification_key: &VerificationKey, attributes: &[Attribute], shares: &[SignatureShare]) -> Result<Signature> {
     let (signatures, indices): (Vec<_>, Vec<_>) = shares
         .iter()
         .map(|share| (*share.signature(), share.index()))
         .unzip();
 
-    aggregate_signatures(&signatures, Some(&indices))
+    aggregate_signatures(&params, &verification_key, &attributes, &signatures, Some(&indices))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use bls12_381::G1Projective;
+    use group::Group;
+
     use crate::scheme::issuance::sign;
     use crate::scheme::keygen::ttp_keygen;
     use crate::scheme::setup::Parameters;
     use crate::scheme::verification::verify;
-    use bls12_381::G1Projective;
-    use group::Group;
+
+    use super::*;
 
     #[test]
     fn key_aggregation_works_for_any_subset_of_keys() {
@@ -189,30 +225,35 @@ mod tests {
             .map(|sk| sign(&mut params, sk, &attributes).unwrap())
             .collect::<Vec<_>>();
 
-        let aggr_sig1 = aggregate_signatures(&sigs[..3], Some(&[1, 2, 3])).unwrap();
-        let aggr_sig2 = aggregate_signatures(&sigs[2..], Some(&[3, 4, 5])).unwrap();
+        // aggregating (any) threshold works
+        let aggr_vk_1 = aggregate_verification_keys(&vks[..3], Some(&[1, 2, 3])).unwrap();
+        let aggr_sig1 = aggregate_signatures(&params, &aggr_vk_1, &attributes, &sigs[..3], Some(&[1, 2, 3])).unwrap();
+
+        let aggr_vk_2 = aggregate_verification_keys(&vks[2..], Some(&[3, 4, 5])).unwrap();
+        let aggr_sig2 = aggregate_signatures(&params, &aggr_vk_1, &attributes, &sigs[2..], Some(&[3, 4, 5])).unwrap();
         assert_eq!(aggr_sig1, aggr_sig2);
 
         // verify credential for good measure
-        let aggr_vk = aggregate_verification_keys(&vks[..3], Some(&[1, 2, 3])).unwrap();
-        assert!(verify(&params, &aggr_vk, &attributes, &aggr_sig1));
+        assert!(verify(&params, &aggr_vk_1, &attributes, &aggr_sig1));
 
-        // TODO: should those two actually work or not?
-        // aggregating threshold+1
-        let aggr_more = aggregate_signatures(&sigs[1..], Some(&[2, 3, 4, 5])).unwrap();
+        // aggregating threshold+1 works
+        let aggr_vk_more = aggregate_verification_keys(&vks[1..], Some(&[2, 3, 4, 5])).unwrap();
+        let aggr_more = aggregate_signatures(&params, &aggr_vk_more, &attributes, &sigs[1..], Some(&[2, 3, 4, 5])).unwrap();
         assert_eq!(aggr_sig1, aggr_more);
 
         // aggregating all
-        let aggr_all = aggregate_signatures(&sigs, Some(&[1, 2, 3, 4, 5])).unwrap();
+        let aggr_vk_all = aggregate_verification_keys(&vks, Some(&[1, 2, 3, 4, 5])).unwrap();
+        let aggr_all = aggregate_signatures(&params, &aggr_vk_all, &attributes, &sigs, Some(&[1, 2, 3, 4, 5])).unwrap();
         assert_eq!(aggr_all, aggr_sig1);
 
-        // not taking enough points (threshold was 3)
-        let aggr_not_enough = aggregate_signatures(&sigs[..2], Some(&[1, 2])).unwrap();
+        // not taking enough points (threshold was 3) should fail
+        let aggr_vk_not_enough = aggregate_verification_keys(&vks[..2], Some(&[1, 2, ])).unwrap();
+        let aggr_not_enough = aggregate_signatures(&params, &aggr_vk_not_enough, &attributes, &sigs[..2], Some(&[1, 2])).unwrap();
         assert_ne!(aggr_not_enough, aggr_sig1);
 
-        // taking wrong index
-        let aggr_bad = aggregate_signatures(&sigs[2..], Some(&[42, 123, 100])).unwrap();
-        assert_ne!(aggr_sig1, aggr_bad);
+        // taking wrong index should fail
+        let aggr_vk_bad = aggregate_verification_keys(&vks[2..], Some(&[1, 2, 3])).unwrap();
+        assert!(aggregate_signatures(&params, &aggr_vk_bad, &attributes, &sigs[2..], Some(&[42, 123, 100])).is_err());
     }
 
     fn random_signature() -> Signature {
@@ -226,22 +267,48 @@ mod tests {
     #[test]
     fn signature_aggregation_doesnt_work_for_empty_set_of_signatures() {
         let signatures: Vec<Signature> = vec![];
-        assert!(aggregate_signatures(&signatures, None).is_err());
+        let mut params = Parameters::new(2).unwrap();
+        let attributes = params.n_random_scalars(2);
+        let keypairs = ttp_keygen(&mut params, 3, 5).unwrap();
+
+        let (sks, vks): (Vec<_>, Vec<_>) = keypairs
+            .into_iter()
+            .map(|keypair| (keypair.secret_key(), keypair.verification_key()))
+            .unzip();
+
+        let aggr_vk_all = aggregate_verification_keys(&vks, None).unwrap();
+        assert!(aggregate_signatures(&params, &aggr_vk_all, &attributes, &signatures, None).is_err());
     }
 
     #[test]
     fn signature_aggregation_doesnt_work_if_indices_have_invalid_length() {
         let signatures = vec![random_signature()];
+        let mut params = Parameters::new(2).unwrap();
+        let attributes = params.n_random_scalars(2);
+        let keypairs = ttp_keygen(&mut params, 3, 5).unwrap();
+        let (sks, vks): (Vec<_>, Vec<_>) = keypairs
+            .into_iter()
+            .map(|keypair| (keypair.secret_key(), keypair.verification_key()))
+            .unzip();
+        let aggr_vk_all = aggregate_verification_keys(&vks, None).unwrap();
 
-        assert!(aggregate_signatures(&signatures, Some(&[])).is_err());
-        assert!(aggregate_signatures(&signatures, Some(&[1, 2])).is_err());
+        assert!(aggregate_signatures(&params, &aggr_vk_all, &attributes, &signatures, Some(&[])).is_err());
+        assert!(aggregate_signatures(&params, &aggr_vk_all, &attributes, &signatures, Some(&[1, 2])).is_err());
     }
 
     #[test]
     fn signature_aggregation_doesnt_work_for_non_unique_indices() {
         let signatures = vec![random_signature(), random_signature()];
+        let mut params = Parameters::new(2).unwrap();
+        let attributes = params.n_random_scalars(2);
+        let keypairs = ttp_keygen(&mut params, 3, 5).unwrap();
+        let (sks, vks): (Vec<_>, Vec<_>) = keypairs
+            .into_iter()
+            .map(|keypair| (keypair.secret_key(), keypair.verification_key()))
+            .unzip();
+        let aggr_vk_all = aggregate_verification_keys(&vks, None).unwrap();
 
-        assert!(aggregate_signatures(&signatures, Some(&[1, 1])).is_err());
+        assert!(aggregate_signatures(&params, &aggr_vk_all, &attributes, &signatures, Some(&[1, 1])).is_err());
     }
 
     // TODO: test for aggregating non-threshold keys

--- a/coconut-rs/src/scheme/aggregation.rs
+++ b/coconut-rs/src/scheme/aggregation.rs
@@ -97,6 +97,8 @@ pub fn aggregate_signatures(
     signatures: &[PartialSignature],
     indices: Option<&[SignerIndex]>,
 ) -> Result<Signature> {
+    // aggregate the signature
+
     let signature = match Aggregatable::aggregate(signatures, indices) {
         Ok(res) => res,
         Err(err) => return Err(err)

--- a/coconut-rs/src/scheme/issuance.rs
+++ b/coconut-rs/src/scheme/issuance.rs
@@ -42,7 +42,7 @@ pub struct BlindSignRequest {
     // cm
     commitment: G1Projective,
     // h
-    commitment_hash: G1Projective,
+    pub commitment_hash: G1Projective,
     // c
     private_attributes_ciphertexts: Vec<elgamal::Ciphertext>,
     // pi_s

--- a/coconut-rs/src/scheme/issuance.rs
+++ b/coconut-rs/src/scheme/issuance.rs
@@ -18,7 +18,7 @@ use std::convert::TryInto;
 use bls12_381::{G1Affine, G1Projective, Scalar};
 use group::{Curve, GroupEncoding};
 
-use crate::{Attribute, elgamal};
+use crate::{Attribute, elgamal, VerificationKey};
 use crate::elgamal::{Ciphertext, EphemeralKey};
 use crate::error::{CoconutError, Result};
 use crate::proofs::ProofCmCs;
@@ -259,6 +259,7 @@ pub fn blind_sign(
         });
     }
 
+    // Verify the commitment hash
     let h = hash_g1(blind_sign_request.commitment.to_bytes());
     if !(h == blind_sign_request.commitment_hash) {
         return Err(CoconutError::Issuance(
@@ -266,12 +267,12 @@ pub fn blind_sign(
         ));
     }
 
+    // Verify the ZK proof
     if !blind_sign_request.verify_proof(params, pub_key) {
         return Err(CoconutError::Issuance(
             "Failed to verify the proof of knowledge".to_string(),
         ));
     }
-
 
     // in python implementation there are n^2 G1 multiplications, let's do it with a single one instead.
     // i.e. compute h ^ (pub_m[0] * y[m + 1] + ... + pub_m[n] * y[m + n]) directly (where m is number of PRIVATE attributes)

--- a/coconut-rs/src/scheme/issuance.rs
+++ b/coconut-rs/src/scheme/issuance.rs
@@ -259,6 +259,12 @@ pub fn blind_sign(
         });
     }
 
+    let h = hash_g1(blind_sign_request.commitment.to_bytes());
+    if !(h == blind_sign_request.commitment_hash) {
+        return Err(CoconutError::Issuance(
+            "Failed to verify the commitment hash".to_string(),
+        ));
+    }
 
     if !blind_sign_request.verify_proof(params, pub_key) {
         return Err(CoconutError::Issuance(
@@ -266,8 +272,6 @@ pub fn blind_sign(
         ));
     }
 
-    // TODO: This should be also checked!!!
-    let h = hash_g1(blind_sign_request.commitment.to_bytes());
 
     // in python implementation there are n^2 G1 multiplications, let's do it with a single one instead.
     // i.e. compute h ^ (pub_m[0] * y[m + 1] + ... + pub_m[n] * y[m + n]) directly (where m is number of PRIVATE attributes)

--- a/coconut-rs/src/scheme/keygen.rs
+++ b/coconut-rs/src/scheme/keygen.rs
@@ -124,8 +124,8 @@ impl Base58 for SecretKey {}
 #[derive(Debug, PartialEq, Clone)]
 pub struct VerificationKey {
     // TODO add gen2 as per the paper or imply it from the fact library is using bls381?
-    pub alpha: G2Projective,
-    pub beta: Vec<G2Projective>,
+    pub(crate) alpha: G2Projective,
+    pub(crate) beta: Vec<G2Projective>,
 }
 
 impl TryFrom<&[u8]> for VerificationKey {
@@ -256,6 +256,14 @@ impl VerificationKey {
 
     pub fn aggregate(sigs: &[Self], indices: Option<&[SignerIndex]>) -> Result<Self> {
         aggregate_verification_keys(sigs, indices)
+    }
+
+    pub fn alpha(&self) -> &G2Projective {
+        &self.alpha
+    }
+
+    pub fn beta(&self) -> &Vec<G2Projective> {
+        &self.beta
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {

--- a/coconut-rs/src/scheme/keygen.rs
+++ b/coconut-rs/src/scheme/keygen.rs
@@ -12,23 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::borrow::Borrow;
+use core::iter::Sum;
+use core::ops::{Add, Mul};
+use std::convert::TryFrom;
+use std::convert::TryInto;
+
+use bls12_381::{G2Projective, Scalar};
+use group::Curve;
+use serde_derive::{Deserialize, Serialize};
+
+use crate::Base58;
 use crate::error::{CoconutError, Result};
 use crate::scheme::aggregation::aggregate_verification_keys;
 use crate::scheme::setup::Parameters;
 use crate::scheme::SignerIndex;
 use crate::traits::Bytable;
 use crate::utils::{
-    try_deserialize_g2_projective, try_deserialize_scalar, try_deserialize_scalar_vec, Polynomial,
+    Polynomial, try_deserialize_g2_projective, try_deserialize_scalar, try_deserialize_scalar_vec,
 };
-use crate::Base58;
-use bls12_381::{G2Projective, Scalar};
-use core::borrow::Borrow;
-use core::iter::Sum;
-use core::ops::{Add, Mul};
-use group::Curve;
-use serde_derive::{Deserialize, Serialize};
-use std::convert::TryFrom;
-use std::convert::TryInto;
 
 #[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
@@ -122,8 +124,8 @@ impl Base58 for SecretKey {}
 #[derive(Debug, PartialEq, Clone)]
 pub struct VerificationKey {
     // TODO add gen2 as per the paper or imply it from the fact library is using bls381?
-    pub(crate) alpha: G2Projective,
-    pub(crate) beta: Vec<G2Projective>,
+    pub alpha: G2Projective,
+    pub beta: Vec<G2Projective>,
 }
 
 impl TryFrom<&[u8]> for VerificationKey {
@@ -148,9 +150,9 @@ impl TryFrom<&[u8]> for VerificationKey {
         if beta_len as usize != actual_beta_len {
             return Err(
                 CoconutError::Deserialization(
-                format!("Tried to deserialize verification key with inconsistent beta len (expected {}, got {})",
-                        beta_len, actual_beta_len
-                )));
+                    format!("Tried to deserialize verification key with inconsistent beta len (expected {}, got {})",
+                            beta_len, actual_beta_len
+                    )));
         }
 
         let alpha = try_deserialize_g2_projective(
@@ -218,13 +220,13 @@ impl<'a> Mul<Scalar> for &'a VerificationKey {
 }
 
 impl<T> Sum<T> for VerificationKey
-where
-    T: Borrow<VerificationKey>,
+    where
+        T: Borrow<VerificationKey>,
 {
     #[inline]
     fn sum<I>(iter: I) -> Self
-    where
-        I: Iterator<Item = T>,
+        where
+            I: Iterator<Item=T>,
     {
         let mut peekable = iter.peekable();
         let head_attributes = match peekable.peek() {
@@ -437,8 +439,8 @@ pub fn ttp_keygen(
     if threshold > num_authorities {
         return Err(
             CoconutError::Setup(
-            "Tried to generate threshold keys for threshold value being higher than number of the signing authorities".to_string(),
-        ));
+                "Tried to generate threshold keys for threshold value being higher than number of the signing authorities".to_string(),
+            ));
     }
 
     let attributes = params.gen_hs().len();
@@ -483,8 +485,9 @@ pub fn ttp_keygen(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::scheme::setup::setup;
+
+    use super::*;
 
     #[test]
     fn keypair_bytes_roundtrip() {

--- a/coconut-rs/src/scheme/mod.rs
+++ b/coconut-rs/src/scheme/mod.rs
@@ -256,7 +256,7 @@ mod tests {
 
         let lambda = prepare_blind_sign(
             &mut params,
-            elgamal_keypair.public_key(),
+            &elgamal_keypair,
             &private_attributes,
             &public_attributes,
         )
@@ -330,7 +330,7 @@ mod tests {
 
         let lambda = prepare_blind_sign(
             &mut params,
-            elgamal_keypair.public_key(),
+            &elgamal_keypair,
             &private_attributes,
             &public_attributes,
         )

--- a/coconut-rs/src/scheme/mod.rs
+++ b/coconut-rs/src/scheme/mod.rs
@@ -14,6 +14,14 @@
 
 // TODO: implement https://crates.io/crates/signature traits?
 
+use std::convert::TryFrom;
+use std::convert::TryInto;
+
+use bls12_381::G1Projective;
+use group::Curve;
+
+pub use keygen::{SecretKey, VerificationKey};
+
 use crate::elgamal;
 use crate::elgamal::Ciphertext;
 use crate::error::{CoconutError, Result};
@@ -21,11 +29,6 @@ use crate::scheme::aggregation::{aggregate_signature_shares, aggregate_signature
 use crate::scheme::setup::Parameters;
 use crate::traits::{Base58, Bytable};
 use crate::utils::try_deserialize_g1_projective;
-use bls12_381::G1Projective;
-use group::Curve;
-pub use keygen::{SecretKey, VerificationKey};
-use std::convert::TryFrom;
-use std::convert::TryInto;
 
 pub mod aggregation;
 pub mod issuance;
@@ -195,11 +198,12 @@ impl SignatureShare {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::scheme::aggregation::aggregate_verification_keys;
     use crate::scheme::issuance::{blind_sign, prepare_blind_sign, sign};
     use crate::scheme::keygen::{keygen, ttp_keygen};
     use crate::scheme::verification::{prove_credential, verify, verify_credential};
+
+    use super::*;
 
     #[test]
     fn verification_on_two_public_attributes() {
@@ -249,7 +253,7 @@ mod tests {
             &private_attributes,
             &public_attributes,
         )
-        .unwrap();
+            .unwrap();
 
         let sig1 = blind_sign(
             &mut params,
@@ -258,8 +262,9 @@ mod tests {
             &lambda,
             &public_attributes,
         )
-        .unwrap()
-        .unblind(elgamal_keypair.private_key());
+            .unwrap()
+            .unblind(elgamal_keypair.private_key());
+
         let sig2 = blind_sign(
             &mut params,
             &keypair2.secret_key(),
@@ -267,8 +272,8 @@ mod tests {
             &lambda,
             &public_attributes,
         )
-        .unwrap()
-        .unblind(elgamal_keypair.private_key());
+            .unwrap()
+            .unblind(elgamal_keypair.private_key());
 
         let theta1 = prove_credential(
             &mut params,
@@ -276,14 +281,14 @@ mod tests {
             &sig1,
             &private_attributes,
         )
-        .unwrap();
+            .unwrap();
         let theta2 = prove_credential(
             &mut params,
             &keypair2.verification_key(),
             &sig2,
             &private_attributes,
         )
-        .unwrap();
+            .unwrap();
 
         assert!(verify_credential(
             &params,
@@ -322,7 +327,7 @@ mod tests {
             &private_attributes,
             &public_attributes,
         )
-        .unwrap();
+            .unwrap();
 
         let sigs = keypairs
             .iter()
@@ -334,8 +339,8 @@ mod tests {
                     &lambda,
                     &public_attributes,
                 )
-                .unwrap()
-                .unblind(elgamal_keypair.private_key())
+                    .unwrap()
+                    .unblind(elgamal_keypair.private_key())
             })
             .collect::<Vec<_>>();
 
@@ -385,7 +390,7 @@ mod tests {
             signature.0.to_affine().to_compressed(),
             signature.1.to_affine().to_compressed(),
         ]
-        .concat();
+            .concat();
         assert_eq!(expected_bytes, bytes);
         assert_eq!(signature, Signature::try_from(&bytes[..]).unwrap())
     }
@@ -405,10 +410,10 @@ mod tests {
         // also make sure it is equivalent to the internal g1 compressed bytes concatenated
         let expected_bytes = [
             blinded_sig.0.to_affine().to_compressed(),
-            blinded_sig.1 .0.to_affine().to_compressed(),
-            blinded_sig.1 .1.to_affine().to_compressed(),
+            blinded_sig.1.0.to_affine().to_compressed(),
+            blinded_sig.1.1.to_affine().to_compressed(),
         ]
-        .concat();
+            .concat();
         assert_eq!(expected_bytes, bytes);
         assert_eq!(blinded_sig, BlindedSignature::try_from(&bytes[..]).unwrap())
     }

--- a/coconut-rs/src/scheme/mod.rs
+++ b/coconut-rs/src/scheme/mod.rs
@@ -91,9 +91,9 @@ impl Signature {
         (Signature(h_prime, s_prime), r)
     }
 
-    pub fn aggregate(sigs: &[Self], indices: Option<&[SignerIndex]>) -> Result<Self> {
-        aggregate_signatures(sigs, indices)
-    }
+    // pub fn aggregate(sigs: &[Self], indices: Option<&[SignerIndex]>) -> Result<Self> {
+    //     aggregate_signatures(sigs, indices)
+    // }
 
     pub fn to_bytes(self) -> [u8; 96] {
         let mut bytes = [0u8; 96];
@@ -178,7 +178,6 @@ impl BlindedSignature {
             ));
         }
 
-        // Verify e (h, ) == e(s_i, g_2)
         let alpha = partial_verification_key.alpha;
 
         let tmp = private_attributes
@@ -237,9 +236,9 @@ impl SignatureShare {
         self.index
     }
 
-    pub fn aggregate(shares: &[Self]) -> Result<Signature> {
-        aggregate_signature_shares(shares)
-    }
+    // pub fn aggregate(shares: &[Self]) -> Result<Signature> {
+    //     aggregate_signature_shares(shares)
+    // }
 }
 
 #[cfg(test)]
@@ -476,8 +475,12 @@ mod tests {
             .map(|keypair| keypair.verification_key())
             .collect::<Vec<_>>();
 
+        let mut attributes = Vec::with_capacity(private_attributes.len() + public_attributes.len());
+        attributes.extend_from_slice(&private_attributes);
+        attributes.extend_from_slice(&public_attributes);
+
         let aggr_vk = aggregate_verification_keys(&vks[..2], Some(&[1, 2])).unwrap();
-        let aggr_sig = aggregate_signatures(&sigs[..2], Some(&[1, 2])).unwrap();
+        let aggr_sig = aggregate_signatures(&params, &aggr_vk, &attributes, &sigs[..2], Some(&[1, 2])).unwrap();
 
         let theta =
             prove_credential(&mut params, &aggr_vk, &aggr_sig, &private_attributes).unwrap();
@@ -491,7 +494,7 @@ mod tests {
 
         // taking different subset of keys and credentials
         let aggr_vk = aggregate_verification_keys(&vks[1..], Some(&[2, 3])).unwrap();
-        let aggr_sig = aggregate_signatures(&sigs[1..], Some(&[2, 3])).unwrap();
+        let aggr_sig = aggregate_signatures(&params, &aggr_vk, &attributes, &sigs[1..], Some(&[2, 3])).unwrap();
 
         let theta =
             prove_credential(&mut params, &aggr_vk, &aggr_sig, &private_attributes).unwrap();

--- a/coconut-rs/src/scheme/mod.rs
+++ b/coconut-rs/src/scheme/mod.rs
@@ -156,7 +156,14 @@ impl TryFrom<&[u8]> for BlindedSignature {
 
 impl BlindedSignature {
     pub fn unblind(&self, private_key: &elgamal::PrivateKey) -> Signature {
-        let sig2 = private_key.decrypt(&self.1);
+        // parse the signature
+        let h = &self.0;
+        let c = &self.1;
+        let sig2 = private_key.decrypt(c);
+        // Verify the commitment hash
+
+        // Verify e (h, ) == e(s_i, g_2)
+
         Signature(self.0, sig2)
     }
 

--- a/coconut-rs/src/scheme/mod.rs
+++ b/coconut-rs/src/scheme/mod.rs
@@ -91,10 +91,6 @@ impl Signature {
         (Signature(h_prime, s_prime), r)
     }
 
-    // pub fn aggregate(sigs: &[Self], indices: Option<&[SignerIndex]>) -> Result<Self> {
-    //     aggregate_signatures(sigs, indices)
-    // }
-
     pub fn to_bytes(self) -> [u8; 96] {
         let mut bytes = [0u8; 96];
         bytes[..48].copy_from_slice(&self.0.to_affine().to_compressed());

--- a/coconut-rs/src/scheme/mod.rs
+++ b/coconut-rs/src/scheme/mod.rs
@@ -289,6 +289,7 @@ mod tests {
             &private_attributes,
         )
             .unwrap();
+
         let theta2 = prove_credential(
             &mut params,
             &keypair2.verification_key(),

--- a/coconut-rs/src/scheme/verification.rs
+++ b/coconut-rs/src/scheme/verification.rs
@@ -75,7 +75,6 @@ impl Theta {
         self.pi_v.verify(
             params,
             verification_key,
-            &self.credential,
             &self.blinded_message,
         )
     }
@@ -170,9 +169,9 @@ pub fn prove_credential(
     let pi_v = ProofKappaNu::construct(
         params,
         verification_key,
-        &signature_prime,
         private_attributes,
         &blinding_factor,
+        &blinded_message,
     );
 
     Ok(Theta {
@@ -208,6 +207,7 @@ pub fn verify_credential(
     //     return false;
     // }
     theta.verify_proof(params, verification_key)
+
     // let kappa = if public_attributes.is_empty() {
     //     theta.blinded_message
     // } else {
@@ -228,7 +228,7 @@ pub fn verify_credential(
     // check_bilinear_pairing(
     //     &theta.credential.0.to_affine(),
     //     &G2Prepared::from(kappa.to_affine()),
-    //     &(theta.credential.1).to_affine(),
+    //     &theta.credential.1.to_affine(),
     //     params.prepared_miller_g2(),
     // ) && !bool::from(theta.credential.0.is_identity())
 }

--- a/coconut-rs/src/scheme/verification.rs
+++ b/coconut-rs/src/scheme/verification.rs
@@ -34,11 +34,11 @@ use crate::utils::{try_deserialize_g1_projective, try_deserialize_g2_projective}
 #[cfg_attr(test, derive(PartialEq))]
 pub struct Theta {
     // blinded_message (kappa)
-    blinded_message: G2Projective,
+    pub blinded_message: G2Projective,
     // sigma
-    credential: Signature,
+    pub credential: Signature,
     // pi_v
-    pi_v: ProofKappaNu,
+    pub pi_v: ProofKappaNu,
 }
 
 impl TryFrom<&[u8]> for Theta {

--- a/coconut-rs/src/scheme/verification.rs
+++ b/coconut-rs/src/scheme/verification.rs
@@ -161,9 +161,7 @@ pub fn prove_credential(
     // Thus, we need kappa which allows us to verify sigma'. In particular,
     // kappa is computed on m as input, but thanks to the use or random value r,
     // it does not reveal any information about m.
-
     let blinded_message = compute_kappa(params, verification_key, private_attributes, blinding_factor);
-    let nu = signature_prime.sig1() * blinding_factor;
 
 
     let pi_v = ProofKappaNu::construct(

--- a/coconut-rs/src/scheme/verification.rs
+++ b/coconut-rs/src/scheme/verification.rs
@@ -180,7 +180,7 @@ pub fn prove_credential(
 }
 
 /// Checks whether e(P, Q) * e(-R, S) == id
-fn check_bilinear_pairing(p: &G1Affine, q: &G2Prepared, r: &G1Affine, s: &G2Prepared) -> bool {
+pub fn check_bilinear_pairing(p: &G1Affine, q: &G2Prepared, r: &G1Affine, s: &G2Prepared) -> bool {
     // checking e(P, Q) * e(-R, S) == id
     // is equivalent to checking e(P, Q) == e(R, S)
     // but requires only a single final exponentiation rather than two of them

--- a/coconut-rs/src/scheme/verification.rs
+++ b/coconut-rs/src/scheme/verification.rs
@@ -143,16 +143,14 @@ pub fn prove_credential(
     if private_attributes.len() > verification_key.beta.len() {
         return Err(
             CoconutError::Verification(
-                format!("tried to prove a credential for higher than supported by the provided verification key number of attributes (max: {}, requested: {})",
+                format!("Tried to prove a credential for higher than supported by the provided verification key number of attributes (max: {}, requested: {})",
                         verification_key.beta.len(),
                         private_attributes.len()
                 )));
     }
 
-    let (signature_prime, blinding_factor) = signature.randomise(params);
-
-    // TODO NAMING: 'kappa', 'nu', 'blinding factor'
-    // let blinding_factor = params.random_scalar();
+    // Randomize the signature
+    let (signature_prime, sign_blinding_factor) = signature.randomise(params);
 
     // blinded_message : kappa in the paper.
     // Value kappa is needed since we want to show a signature sigma'.
@@ -161,14 +159,14 @@ pub fn prove_credential(
     // Thus, we need kappa which allows us to verify sigma'. In particular,
     // kappa is computed on m as input, but thanks to the use or random value r,
     // it does not reveal any information about m.
-    let blinded_message = compute_kappa(params, verification_key, private_attributes, blinding_factor);
+    let blinded_message = compute_kappa(params, verification_key, private_attributes, sign_blinding_factor);
 
 
     let pi_v = ProofKappaNu::construct(
         params,
         verification_key,
         private_attributes,
-        &blinding_factor,
+        &sign_blinding_factor,
         &blinded_message,
     );
 

--- a/coconut-rs/src/tests/e2e.rs
+++ b/coconut-rs/src/tests/e2e.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), CoconutError> {
     let unblinded_signatures: Vec<Signature> = blinded_signatures
         .into_iter()
         .zip(verification_keys.iter())
-        .map(|(signature, verification_key)| signature.unblind(&params, &elgamal_keypair.private_key(), &verification_key, &private_attributes, &public_attributes).unwrap())
+        .map(|(signature, verification_key)| signature.unblind(&params, &elgamal_keypair.private_key(), &verification_key, &private_attributes, &public_attributes, blind_sign_request.commitment_hash).unwrap())
         .collect();
 
     // Aggregate signatures

--- a/coconut-rs/src/tests/e2e.rs
+++ b/coconut-rs/src/tests/e2e.rs
@@ -50,7 +50,8 @@ fn main() -> Result<(), CoconutError> {
 
     let unblinded_signatures: Vec<Signature> = blinded_signatures
         .into_iter()
-        .map(|signature| signature.unblind(&elgamal_keypair.private_key()))
+        .zip(verification_keys.iter())
+        .map(|(signature, verification_key)| signature.unblind(&params, &elgamal_keypair.private_key(), &verification_key, &private_attributes, &public_attributes).unwrap())
         .collect();
 
     // Aggregate signatures

--- a/coconut-rs/src/tests/e2e.rs
+++ b/coconut-rs/src/tests/e2e.rs
@@ -62,8 +62,12 @@ fn main() -> Result<(), CoconutError> {
         .map(|(idx, signature)| SignatureShare::new(*signature, (idx + 1) as u64))
         .collect();
 
+    let mut attributes = Vec::with_capacity(private_attributes.len() + public_attributes.len());
+    attributes.extend_from_slice(&private_attributes);
+    attributes.extend_from_slice(&public_attributes);
+
     // Randomize credentials and generate any cryptographic material to verify them
-    let signature = aggregate_signature_shares(&signature_shares)?;
+    let signature = aggregate_signature_shares(&params, &verification_key, &attributes, &signature_shares)?;
 
     // Generate cryptographic material to verify them
 

--- a/coconut-rs/src/tests/e2e.rs
+++ b/coconut-rs/src/tests/e2e.rs
@@ -1,7 +1,7 @@
 use crate::{
-    aggregate_signature_shares, aggregate_verification_keys, blind_sign, elgamal_keygen,
-    prepare_blind_sign, prove_credential, setup, ttp_keygen, verify_credential, CoconutError,
-    Signature, SignatureShare, VerificationKey,
+    aggregate_signature_shares, aggregate_verification_keys, blind_sign, CoconutError,
+    elgamal_keygen, prepare_blind_sign, prove_credential, setup, Signature, SignatureShare,
+    ttp_keygen, VerificationKey, verify_credential,
 };
 
 #[test]
@@ -16,7 +16,7 @@ fn main() -> Result<(), CoconutError> {
     // generate commitment and encryption
     let blind_sign_request = prepare_blind_sign(
         &params,
-        &elgamal_keypair.public_key(),
+        &elgamal_keypair,
         &private_attributes,
         &public_attributes,
     )?;
@@ -74,7 +74,7 @@ fn main() -> Result<(), CoconutError> {
         &params,
         &verification_key,
         &theta,
-        &public_attributes
+        &public_attributes,
     ));
 
     Ok(())

--- a/coconut-rs/src/utils.rs
+++ b/coconut-rs/src/utils.rs
@@ -12,15 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::iter::Sum;
+use core::ops::Mul;
+use std::convert::TryInto;
+
+use bls12_381::{G1Affine, G1Projective, G2Affine, G2Projective, Scalar};
+use bls12_381::hash_to_curve::{ExpandMsgXmd, HashToCurve, HashToField};
+use ff::Field;
+
 use crate::error::{CoconutError, Result};
 use crate::scheme::setup::Parameters;
 use crate::scheme::SignerIndex;
-use bls12_381::hash_to_curve::{ExpandMsgXmd, HashToCurve, HashToField};
-use bls12_381::{G1Affine, G1Projective, G2Affine, G2Projective, Scalar};
-use core::iter::Sum;
-use core::ops::Mul;
-use ff::Field;
-use std::convert::TryInto;
 
 pub struct Polynomial {
     coefficients: Vec<Scalar>,
@@ -39,8 +41,8 @@ impl Polynomial {
     pub fn evaluate(&self, x: &Scalar) -> Scalar {
         if self.coefficients.is_empty() {
             Scalar::zero()
-        // if x is zero then we can ignore most of the expensive computation and
-        // just return the last term of the polynomial
+            // if x is zero then we can ignore most of the expensive computation and
+            // just return the last term of the polynomial
         } else if x.is_zero() {
             // we checked that coefficients are not empty so unwrap here is fine
             *self.coefficients.first().unwrap()
@@ -90,9 +92,9 @@ pub(crate) fn perform_lagrangian_interpolation_at_origin<T>(
     points: &[SignerIndex],
     values: &[T],
 ) -> Result<T>
-where
-    T: Sum,
-    for<'a> &'a T: Mul<Scalar, Output = T>,
+    where
+        T: Sum,
+        for<'a> &'a T: Mul<Scalar, Output=T>,
 {
     if points.is_empty() || values.is_empty() {
         return Err(CoconutError::Interpolation(
@@ -264,8 +266,9 @@ pub(crate) fn try_deserialize_g2_projective(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use rand::RngCore;
+
+    use super::*;
 
     #[test]
     fn polynomial_evaluation() {


### PR DESCRIPTION
Updates in the Coconut library:

* Remove the use of nu in the showing protocol to provide unconditional unlinkability
* Add signature verification and integrity checks in the issuance and aggregation protocols 
* Checks and corrections in the zk proofs 